### PR TITLE
Publish gotopt2@2.0.1

### DIFF
--- a/modules/gotopt2/2.0.1/MODULE.bazel
+++ b/modules/gotopt2/2.0.1/MODULE.bazel
@@ -1,0 +1,25 @@
+module(
+    name = "gotopt2",
+    version = "2.0.1",
+)
+
+bazel_dep(name = "rules_go", version = "0.50.1", repo_name = "io_bazel_rules_go")
+bazel_dep(name = "gazelle", version = "0.42.0", repo_name = "bazel_gazelle")
+bazel_dep(name = "buildifier_prebuilt", version = "6.4.0")
+bazel_dep(name = "bazel_bats", version = "0.35.0")
+bazel_dep(name = "rules_pkg", version = "1.0.1")
+
+# Go SDK
+
+go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(version = "1.24.1")
+
+go_deps = use_extension("@bazel_gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+
+# All *direct* Go dependencies of the module have to be listed explicitly.
+use_repo(
+    go_deps,
+    "com_github_google_go_cmp",
+    "in_gopkg_yaml_v3",
+)

--- a/modules/gotopt2/2.0.1/presubmit.yml
+++ b/modules/gotopt2/2.0.1/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "integration"
+  matrix:
+    platform: ["ubuntu2204"]
+    bazel: [8.x]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/gotopt2/2.0.1/source.json
+++ b/modules/gotopt2/2.0.1/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-0KIJ3uGN8ewDnM5e8hZOPyIAnrSS5HIWgDdUANblVF4=",
+    "strip_prefix": "gotopt2-2.0.1",
+    "url": "https://github.com/filmil/gotopt2/archive/refs/tags/v2.0.1.zip"
+}

--- a/modules/gotopt2/metadata.json
+++ b/modules/gotopt2/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/filmil/gotopt2",
+    "maintainers": [
+        {
+            "name": "Filip Filmar",
+            "email": "246576+filmil@users.noreply.github.com",
+            "github": "filmil",
+            "github_user_id": 246576
+        }
+    ],
+    "repository": [
+        "github:filmil/gotopt2"
+    ],
+    "versions": [
+        "2.0.1"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/filmil/gotopt2/releases/tag/v2.0.1

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_