### PR TITLE
Publish bazel-go-basic@0.1.4

### DIFF
--- a/modules/bazel-go-basic/0.1.4/MODULE.bazel
+++ b/modules/bazel-go-basic/0.1.4/MODULE.bazel
@@ -1,0 +1,25 @@
+###############################################################################
+# Bazel now uses Bzlmod by default to manage external dependencies.
+# Please consider migrating your external dependencies from WORKSPACE to MODULE.bazel.
+#
+# For more details, please check https://github.com/bazelbuild/bazel/issues/18958
+###############################################################################
+
+module(
+    name = "bazel-go-basic",
+    version = "0.1.4",
+)
+
+bazel_dep(name = "rules_go", version = "0.57.0")
+bazel_dep(name = "gazelle", version = "0.45.0")
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2")
+bazel_dep(name = "rules_pkg", version = "1.0.1")
+
+# Go SDK
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+
+# Download an SDK for the host OS & architecture as well as common remote execution platforms.
+go_sdk.download(version = "1.25.0")
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")

--- a/modules/bazel-go-basic/0.1.4/patches/module_dot_bazel_version.patch
+++ b/modules/bazel-go-basic/0.1.4/patches/module_dot_bazel_version.patch
@@ -1,0 +1,14 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -6,9 +6,9 @@
+ ###############################################################################
+ 
+ module(
+     name = "bazel-go-basic",
+-    version = "0.0.0",
++    version = "0.1.4",
+ )
+ 
+ bazel_dep(name = "rules_go", version = "0.57.0")
+ bazel_dep(name = "gazelle", version = "0.45.0")

--- a/modules/bazel-go-basic/0.1.4/presubmit.yml
+++ b/modules/bazel-go-basic/0.1.4/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "integration"
+  matrix:
+    platform: ["ubuntu2204"]
+    bazel: [8.x]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/bazel-go-basic/0.1.4/source.json
+++ b/modules/bazel-go-basic/0.1.4/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-M9gYU8tydTxugs0USHdP7ssu15oNaPuk2g2XOM2qPM0=",
+    "strip_prefix": "",
+    "url": "https://github.com/filmil/bazel-go-basic/releases/download/v0.1.4/bazel-go-basic-v0.1.4.zip",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-yChEMGmEWh2sgc1Yp/M0fVoZljnBoDi8AmqK7ZjshFE="
+    },
+    "patch_strip": 1
+}

--- a/modules/bazel-go-basic/metadata.json
+++ b/modules/bazel-go-basic/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/filmil/bazel-go-basic",
+    "maintainers": [
+        {
+            "name": "Filip Filmar",
+            "email": "246576+filmil@users.noreply.github.com",
+            "github": "filmil",
+            "github_user_id": 246576
+        }
+    ],
+    "repository": [
+        "github:filmil/bazel-go-basic"
+    ],
+    "versions": [
+        "0.1.4"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Release: https://github.com/filmil/bazel-go-basic/releases/tag/v0.1.4

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_