### PR TITLE
Publish lit2md@0.2.3

### DIFF
--- a/modules/lit2md/0.2.3/MODULE.bazel
+++ b/modules/lit2md/0.2.3/MODULE.bazel
@@ -1,0 +1,23 @@
+# LICENSE sha265: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+module(
+    name = "lit2md",
+    version = "0.2.3",
+)
+
+bazel_dep(name = "rules_go", version = "0.57.0")
+bazel_dep(name = "gazelle", version = "0.45.0")
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2")
+bazel_dep(name = "rules_pkg", version = "1.0.1")
+bazel_dep(name = "aspect_bazel_lib", version = "2.21.1")
+
+# go
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.download(version = "1.25.0")
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+
+# multitool
+bazel_dep(name = "rules_multitool", version = "1.9.0")
+multitool = use_extension("@rules_multitool//multitool:extension.bzl", "multitool")
+multitool.hub(lockfile = "//:multitool.lock.json")
+use_repo(multitool, "multitool")

--- a/modules/lit2md/0.2.3/patches/module_dot_bazel_version.patch
+++ b/modules/lit2md/0.2.3/patches/module_dot_bazel_version.patch
@@ -1,0 +1,13 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,8 +1,8 @@
+ # LICENSE sha265: c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
+ module(
+     name = "lit2md",
+-    version = "0.0.0",
++    version = "0.2.3",
+ )
+ 
+ bazel_dep(name = "rules_go", version = "0.57.0")
+ bazel_dep(name = "gazelle", version = "0.45.0")

--- a/modules/lit2md/0.2.3/presubmit.yml
+++ b/modules/lit2md/0.2.3/presubmit.yml
@@ -1,0 +1,12 @@
+bcr_test_module:
+  module_path: "integration"
+  matrix:
+    platform: ["ubuntu2204"]
+    bazel: [8.x]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."

--- a/modules/lit2md/0.2.3/source.json
+++ b/modules/lit2md/0.2.3/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-1tGKOaAsr1s7I/qlnD/7i2o7NOrg/oFA/zZirlVlvaw=",
+    "strip_prefix": "",
+    "url": "https://github.com/filmil/lit2md/releases/download/v0.2.3/lit2md-v0.2.3.zip",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-p567/Wc/D+giYAvA5NQdcaTQ2SFNK8rGBgJ8l0il6Go="
+    },
+    "patch_strip": 1
+}

--- a/modules/lit2md/metadata.json
+++ b/modules/lit2md/metadata.json
@@ -12,7 +12,8 @@
         "github:filmil/lit2md"
     ],
     "versions": [
-        "0.1.1"
+        "0.1.1",
+        "0.2.3"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/filmil/lit2md/releases/tag/v0.2.3

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_