### PR TITLE
Publish upspin_drive@42.1.0

### DIFF
--- a/modules/upspin_drive/42.1.0/MODULE.bazel
+++ b/modules/upspin_drive/42.1.0/MODULE.bazel
@@ -1,0 +1,53 @@
+module(
+    name = "upspin_drive",
+    version = "42.1.0",
+)
+
+bazel_dep(name = "rules_go", version = "0.60.0")
+bazel_dep(name = "gazelle", version = "0.50.0")
+bazel_dep(name = "upspin", version = "43.0.1")
+
+git_override(
+    module_name = "upspin",
+    commit = "a73a39e10e1e2995600c250d6e330c0e374ba7eb",
+    remote = "https://github.com/filmil/upspin.git",
+)
+
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+
+go_sdk.download(version = "1.26.2")
+
+go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")
+go_deps.from_file(go_mod = "//:go.mod")
+go_deps.gazelle_override(
+    build_file_generation = "off",
+    path = "upspin.io",
+)
+
+# Use this to generate the go_deps.bzl file
+use_repo(
+    go_deps,
+    "io_upspin",
+    "org_golang_google_api",
+    "org_golang_x_oauth2",
+)
+
+bazel_dep(name = "rules_oci", version = "2.2.0")
+bazel_dep(name = "rules_pkg", version = "1.0.1")
+bazel_dep(name = "platforms", version = "1.0.0")
+bazel_dep(name = "bazel_lib", version = "3.0.0")
+
+oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
+oci.pull(
+    name = "distroless_base",
+    digest = "sha256:20bc6c0bc4d625a22a8fde3e55f6515709b32055ef8fb9cfbddaa06d1760f838",
+    image = "gcr.io/distroless/static-debian12",
+    platforms = [
+        "linux/amd64",
+        "linux/arm/v7",
+        "linux/arm64/v8",
+        "linux/ppc64le",
+        "linux/s390x",
+    ],
+)
+use_repo(oci, "distroless_base", "distroless_base_linux_amd64", "distroless_base_linux_arm64_v8", "distroless_base_linux_arm_v7", "distroless_base_linux_ppc64le", "distroless_base_linux_s390x")

--- a/modules/upspin_drive/42.1.0/patches/module_dot_bazel_version.patch
+++ b/modules/upspin_drive/42.1.0/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,7 @@
+ module(
+     name = "upspin_drive",
+-    version = "0.1.1",
++    version = "42.1.0",
+ )
+ 
+ bazel_dep(name = "rules_go", version = "0.60.0")
+ bazel_dep(name = "gazelle", version = "0.50.0")

--- a/modules/upspin_drive/42.1.0/presubmit.yml
+++ b/modules/upspin_drive/42.1.0/presubmit.yml
@@ -1,0 +1,10 @@
+matrix:
+  platform: ["ubuntu2204"]
+  bazel: [9.x]
+tasks:
+  run_tests:
+    name: "Run tests"
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    test_targets:
+      - "//..."

--- a/modules/upspin_drive/42.1.0/source.json
+++ b/modules/upspin_drive/42.1.0/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-6JIs6Lc866SqPc5etW2+qNv7dgSltVv4rcfSjL6bizc=",
+    "strip_prefix": "upspin-gdrive-42.1.0",
+    "url": "https://github.com/filmil/upspin-gdrive/archive/refs/tags/v42.1.0.tar.gz",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-pFaaOCTj3RuT5nn7kaY5w4wXN/CQ/LfVNrsA9BqEjbE="
+    },
+    "patch_strip": 1
+}

--- a/modules/upspin_drive/metadata.json
+++ b/modules/upspin_drive/metadata.json
@@ -12,7 +12,8 @@
         "github:filmil/upspin-gdrive"
     ],
     "versions": [
-        "0.1.2"
+        "0.1.2",
+        "42.1.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/filmil/upspin-gdrive/releases/tag/v42.1.0

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_