### PR TITLE
feat: Add zippies to generated registry page

### DIFF
--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -319,7 +319,8 @@ const htmlTemplate = `
                         {{if gt (len $module.Versions) 0}}
                             {{$latest := index $module.Versions 0}}
                             {{if gt (len $latest.Dependencies) 0}}
-                                <p class="card-text mb-1"><strong>Dependencies (Latest):</strong></p>
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
                                 <ul class="list-unstyled mb-2 ms-2">
                                 {{range $dep := $latest.Dependencies}}
                                     <li>
@@ -328,6 +329,7 @@ const htmlTemplate = `
                                     </li>
                                 {{end}}
                                 </ul>
+                                </details>
                             {{end}}
                         {{end}}
                         <p class="card-text"><a href="{{$module.Metadata.Homepage}}">{{$module.Metadata.Homepage}}</a></p>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,5492 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Bazel Registry</title>
+    <link
+		href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css"
+		rel="stylesheet"
+	>
+    <link
+		href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.3/font/bootstrap-icons.css"
+		rel="stylesheet"
+	>
+	<link rel="icon" href="hdlfactory.png" type="image/png">
+
+	<script async src="https://www.googletagmanager.com/gtag/js?id=G-BKGTF9GD1K"></script>
+	<script>
+	  window.dataLayer = window.dataLayer || [];
+	  function gtag(){dataLayer.push(arguments);}
+	  gtag('js', new Date());
+
+	  gtag('config', 'G-BKGTF9GD1K');
+	</script>
+</head>
+<body>
+    <div class="container">
+		<h1 class="mt-5"><a href="https://www.hdlfactory.com">My</a> <a
+		href="https://bazel.build">Bazel</a> Registry</h1>
+
+		<p>These modules are published in <a
+		href="https://github.com/filmil/bazel-registry">my private bazel
+		registry</a> See the <a
+		href="https://github.com/filmil/bazel-registry#usage">usage details</a>
+		for how to configure bazel use this additional registry. </p>
+
+		<p> The bazel central registry is still available at <a
+		href="https://bcr.bazel.build"> https://bcr.bazel.build</a>. </p>
+
+        <input class="form-control mb-4" id="searchInput" type="text" placeholder="Search for modules...">
+        <div class="row" id="module-cards">
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							bazel-go-basic
+							<a href="https://github.com/filmil/bazel-go-basic"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel-go-basic&#34;, version = &#34;0.2.21&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel-go-basic/0.2.21">0.2.21</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel-go-basic\u0022, version = \u00220.2.21\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel-go-basic&#34;, version = &#34;0.2.20&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel-go-basic/0.2.20">0.2.20</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel-go-basic\u0022, version = \u00220.2.20\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel-go-basic&#34;, version = &#34;0.2.19&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel-go-basic/0.2.19">0.2.19</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel-go-basic\u0022, version = \u00220.2.19\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel-go-basic&#34;, version = &#34;0.1.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel-go-basic/0.1.4">0.1.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel-go-basic\u0022, version = \u00220.1.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>buildifier_prebuilt</code> (8.2.0.2)
+
+                                    </li>
+
+                                    <li>
+                                        <code>gazelle</code> (0.45.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_go</code> (0.57.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_pkg</code> (1.0.1)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://github.com/filmil/bazel-go-basic">https://github.com/filmil/bazel-go-basic</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/bazel-go-basic">github:filmil/bazel-go-basic</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							bazel_bats
+							<a href="https://www.hdlfactory.com"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_bats&#34;, version = &#34;0.38.23&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_bats/0.38.23">0.38.23</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_bats\u0022, version = \u00220.38.23\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_bats&#34;, version = &#34;0.37.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_bats/0.37.1">0.37.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_bats\u0022, version = \u00220.37.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_bats&#34;, version = &#34;0.37.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_bats/0.37.0">0.37.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_bats\u0022, version = \u00220.37.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_bats&#34;, version = &#34;0.36.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_bats/0.36.4">0.36.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_bats\u0022, version = \u00220.36.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_bats&#34;, version = &#34;0.36.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_bats/0.36.2">0.36.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_bats\u0022, version = \u00220.36.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_bats&#34;, version = &#34;0.36.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_bats/0.36.0">0.36.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_bats\u0022, version = \u00220.36.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>bazel_skylib</code> (1.7.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>bazel_skylib_gazelle_plugin</code> (1.7.1)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+
+                                    <li>
+                                        <code>gazelle</code> (0.42.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://www.hdlfactory.com">https://www.hdlfactory.com</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/bazel-bats">github:filmil/bazel-bats</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							bazel_ebook
+							<a href="https://hdlfactory.com/post/2025/02/04/typeset-your-own-ebooks-easily-with-bazel-ebook"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;2.0.15&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/2.0.15">2.0.15</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00222.0.15\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;1.0.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/1.0.0">1.0.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.2.5&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.2.5">0.2.5</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.2.5\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.2.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.2.4">0.2.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.2.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.2.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.2.3">0.2.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.2.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.2.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.2.2">0.2.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.2.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.2.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.2.1">0.2.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.2.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.1.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.1.1">0.1.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.1.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.0.5&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.0.5">0.0.5</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.0.5\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.0.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.0.4">0.0.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.0.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.0.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.0.3">0.0.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.0.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.0.1">0.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>bazel_bats</code> (0.38.9)
+
+                                    </li>
+
+                                    <li>
+                                        <code>bazel_rules_bid</code> (1.2.4)
+
+                                    </li>
+
+                                    <li>
+                                        <code>bazel_skylib</code> (1.9.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>buildifier_prebuilt</code> (8.2.1.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>gazelle</code> (0.47.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>platforms</code> (1.0.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_cc</code> (0.2.16)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_multitool</code> (1.11.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_pkg</code> (1.2.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_python</code> (1.8.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_python_gazelle_plugin</code> (1.8.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://hdlfactory.com/post/2025/02/04/typeset-your-own-ebooks-easily-with-bazel-ebook">https://hdlfactory.com/post/2025/02/04/typeset-your-own-ebooks-easily-with-bazel-ebook</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/bazel-ebook">github:filmil/bazel-ebook</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							bazel_rootfs
+							<a href="https://hdlfactory.com/tags/bazel-modules"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rootfs&#34;, version = &#34;1.0.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rootfs/1.0.3">1.0.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rootfs\u0022, version = \u00221.0.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rootfs&#34;, version = &#34;1.0.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rootfs/1.0.2">1.0.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rootfs\u0022, version = \u00221.0.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rootfs&#34;, version = &#34;1.0.18&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rootfs/1.0.18">1.0.18</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rootfs\u0022, version = \u00221.0.18\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rootfs&#34;, version = &#34;1.0.12&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rootfs/1.0.12">1.0.12</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rootfs\u0022, version = \u00221.0.12\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rootfs&#34;, version = &#34;1.0.10&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rootfs/1.0.10">1.0.10</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rootfs\u0022, version = \u00221.0.10\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rootfs&#34;, version = &#34;1.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rootfs/1.0.1">1.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rootfs\u0022, version = \u00221.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>bazel_rules_bid</code> (0.3.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>bazel_skylib</code> (1.7.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>gotopt2</code> (2.2.2)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_distroless</code> (0.5.3)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_multitool</code> (1.9.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_oci</code> (2.2.6)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_zstd</code> (1.0.0)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://hdlfactory.com/tags/bazel-modules">https://hdlfactory.com/tags/bazel-modules</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/bazel_debian_rootfs">github:filmil/bazel_debian_rootfs</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							bazel_rules_bid
+							<a href="https://hdlfactory.com/post/2025/02/11/bazel-rules-for-build-in-docker-or-bid/"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.4.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.4.0">1.4.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.4.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.3.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.3.0">1.3.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.3.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.2.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.2.4">1.2.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.2.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.2.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.2.3">1.2.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.2.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.2.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.2.2">1.2.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.2.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.2.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.2.1">1.2.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.2.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.2.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.2.0">1.2.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.2.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.1.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.1.3">1.1.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.1.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.1.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.1.2">1.1.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.1.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.1.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.1.1">1.1.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.1.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.1.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.1.0">1.1.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.1.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.0.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.0.4">1.0.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.0.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.0.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.0.3">1.0.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.0.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.0.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.0.2">1.0.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.0.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.0.10&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.0.10">1.0.10</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.0.10\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.0.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.0.0">1.0.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;0.3.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/0.3.0">0.3.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00220.3.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;0.2.5&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/0.2.5">0.2.5</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00220.2.5\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;0.2.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/0.2.4">0.2.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00220.2.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;0.2.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/0.2.3">0.2.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00220.2.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;0.2.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/0.2.2">0.2.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00220.2.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;0.2.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/0.2.1">0.2.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00220.2.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;0.2.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/0.2.0">0.2.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00220.2.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>bazel_skylib</code> (1.7.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>bazel_skylib_gazelle_plugin</code> (1.7.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>buildifier_prebuilt</code> (7.3.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>fshlib</code> (0.2.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_multitool</code> (1.0.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://hdlfactory.com/post/2025/02/11/bazel-rules-for-build-in-docker-or-bid/">https://hdlfactory.com/post/2025/02/11/bazel-rules-for-build-in-docker-or-bid/</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/bazel-rules-bid">github:filmil/bazel-rules-bid</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							bazel_rules_bt
+							<a href="https://www.hdlfactory.com"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bt&#34;, version = &#34;0.0.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bt/0.0.3">0.0.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bt\u0022, version = \u00220.0.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bt&#34;, version = &#34;0.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bt/0.0.1">0.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bt\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>rules_multitool</code> (1.8.0)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://www.hdlfactory.com">https://www.hdlfactory.com</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/bazel_rules_bt">github:filmil/bazel_rules_bt</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							bazel_rules_ghdl
+							<a href="https://github.com/filmil/bazel_rules_ghdl"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.7&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.7">0.1.7</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.7\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.6&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.6">0.1.6</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.6\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.5&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.5">0.1.5</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.5\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.4">0.1.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.3">0.1.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.24&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.24">0.1.24</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.24\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.21&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.21">0.1.21</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.21\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.19&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.19">0.1.19</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.19\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.17&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.17">0.1.17</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.17\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.15&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.15">0.1.15</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.15\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.13&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.13">0.1.13</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.13\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.12&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.12">0.1.12</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.12\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.10&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.10">0.1.10</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.10\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.1">0.1.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.0">0.1.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.0.1">0.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>bazel_rules_bid</code> (0.3.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>bazel_skylib</code> (1.7.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>gotopt2</code> (2.2.2)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_distroless</code> (0.5.3)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_multitool</code> (1.9.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_oci</code> (2.2.6)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://github.com/filmil/bazel_rules_ghdl">https://github.com/filmil/bazel_rules_ghdl</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/bazel_go_basic">github:filmil/bazel_go_basic</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							bazel_rules_nvc
+							<a href="https://github.com/filmil/bazel_rules_nvc"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.5.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.5.2">0.5.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.5.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.5.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.5.1">0.5.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.5.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.5.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.5.0">0.5.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.5.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.4.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.4.1">0.4.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.4.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.4.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.4.0">0.4.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.4.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.3.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.3.2">0.3.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.3.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.3.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.3.1">0.3.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.3.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.3.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.3.0">0.3.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.3.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.9&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.9">0.2.9</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.9\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.8&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.8">0.2.8</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.8\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.7&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.7">0.2.7</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.7\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.6&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.6">0.2.6</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.6\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.4">0.2.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.2">0.2.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.11&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.11">0.2.11</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.11\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.10&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.10">0.2.10</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.10\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.1">0.2.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.0">0.2.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.1.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.1.0">0.1.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.1.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.0.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.0.2">0.0.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.0.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.0.1">0.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>bazel_lib</code> (3.0.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>bazel_skylib</code> (1.8.2)
+
+                                    </li>
+
+                                    <li>
+                                        <code>bazel_skylib_gazelle_plugin</code> (1.8.2)
+
+                                    </li>
+
+                                    <li>
+                                        <code>elfutils</code> (0.4.4)
+
+                                    </li>
+
+                                    <li>
+                                        <code>fshlib</code> (0.1.5)
+
+                                    </li>
+
+                                    <li>
+                                        <code>gazelle</code> (0.47.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>gotopt2</code> (2.2.2)
+
+                                    </li>
+
+                                    <li>
+                                        <code>libffi</code> (3.4.7.bcr.3)
+
+                                    </li>
+
+                                    <li>
+                                        <code>platforms</code> (1.0.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_cc</code> (0.2.8)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_foreign_cc</code> (0.15.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>toolchains_llvm</code> (1.5.0)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+
+                                    <li>
+                                        <code>zlib</code> (1.3.1.bcr.7)
+
+                                    </li>
+
+                                    <li>
+                                        <code>zstd</code> (1.5.7)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://github.com/filmil/bazel_rules_nvc">https://github.com/filmil/bazel_rules_nvc</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/bazel_rules_nvc">github:filmil/bazel_rules_nvc</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							bazel_rules_osvvm
+							<a href="https://github.com/filmil/bazel_nvc_osvvm"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_osvvm&#34;, version = &#34;0.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_osvvm/0.0.1">0.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_osvvm\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>bazel_rules_nvc</code> (0.5.2)
+
+                                    </li>
+
+                                    <li>
+                                        <code>toolchains_llvm</code> (1.5.0)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://github.com/filmil/bazel_nvc_osvvm">https://github.com/filmil/bazel_nvc_osvvm</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/bazel_nvc_osvvm">github:filmil/bazel_nvc_osvvm</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							bazel_rules_raylib
+							<a href="https://github.com/filmil/bazel_rules_raylib"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_raylib&#34;, version = &#34;0.0.7&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_raylib/0.0.7">0.0.7</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_raylib\u0022, version = \u00220.0.7\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_raylib&#34;, version = &#34;0.0.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_raylib/0.0.4">0.0.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_raylib\u0022, version = \u00220.0.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_raylib&#34;, version = &#34;0.0.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_raylib/0.0.2">0.0.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_raylib\u0022, version = \u00220.0.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_raylib&#34;, version = &#34;0.0.19&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_raylib/0.0.19">0.0.19</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_raylib\u0022, version = \u00220.0.19\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_raylib&#34;, version = &#34;0.0.16&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_raylib/0.0.16">0.0.16</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_raylib\u0022, version = \u00220.0.16\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_raylib&#34;, version = &#34;0.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_raylib/0.0.1">0.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_raylib\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>bazel_skylib</code> (1.7.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>glew</code> (2.2.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>glfw</code> (3.3.9)
+
+                                    </li>
+
+                                    <li>
+                                        <code>glm</code> (1.0.0.bcr.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>googletest</code> (1.16.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>hermetic_cc_toolchain</code> (3.1.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>platforms</code> (0.0.11)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_cc</code> (0.1.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_foreign_cc</code> (0.14.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://github.com/filmil/bazel_rules_raylib">https://github.com/filmil/bazel_rules_raylib</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/bazel_rules_raylib">github:filmil/bazel_rules_raylib</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							bazel_rules_vivado
+							<a href="https://github.com/filmil/bazel_rules_vivado"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;3.0.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/3.0.0">3.0.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00223.0.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;2.0.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/2.0.0">2.0.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00222.0.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;1.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/1.0.1">1.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00221.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;1.0.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/1.0.0">1.0.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.5.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.5.1">0.5.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.5.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.5.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.5.0">0.5.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.5.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.4.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.4.0">0.4.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.4.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.3.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.3.1">0.3.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.3.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.3.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.3.0">0.3.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.3.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.2.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.2.0">0.2.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.2.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.1.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.1.0">0.1.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.1.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.9&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.9">0.0.9</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.9\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.8&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.8">0.0.8</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.8\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.6&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.6">0.0.6</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.6\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.5&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.5">0.0.5</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.5\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.4">0.0.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.14&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.14">0.0.14</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.14\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.11&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.11">0.0.11</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.11\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.10&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.10">0.0.10</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.10\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>bazel_skylib</code> (1.8.2)
+
+                                    </li>
+
+                                    <li>
+                                        <code>fshlib</code> (0.2.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>gazelle</code> (0.45.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>gotopt2</code> (2.2.4)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_bid</code> (2.0.3)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_go</code> (0.59.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://github.com/filmil/bazel_rules_vivado">https://github.com/filmil/bazel_rules_vivado</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/bazel_rules_vivado">github:filmil/bazel_rules_vivado</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							bazoekt
+							<a href="https://github.com/filmil/bazoekt"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazoekt&#34;, version = &#34;0.1.5&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazoekt/0.1.5">0.1.5</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazoekt\u0022, version = \u00220.1.5\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazoekt&#34;, version = &#34;0.1.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazoekt/0.1.4">0.1.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazoekt\u0022, version = \u00220.1.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazoekt&#34;, version = &#34;0.1.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazoekt/0.1.3">0.1.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazoekt\u0022, version = \u00220.1.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazoekt&#34;, version = &#34;0.1.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazoekt/0.1.2">0.1.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazoekt\u0022, version = \u00220.1.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazoekt&#34;, version = &#34;0.1.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazoekt/0.1.1">0.1.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazoekt\u0022, version = \u00220.1.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>buildifier_prebuilt</code> (8.0.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>gazelle</code> (0.42.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>gotopt2</code> (2.3.3)
+
+                                    </li>
+
+                                    <li>
+                                        <code>protobuf</code> (33.4)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_go</code> (0.60.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_pkg</code> (1.0.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_python</code> (1.7.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://github.com/filmil/bazoekt">https://github.com/filmil/bazoekt</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/bazoekt">github:filmil/bazoekt</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							elfutils
+							<a href="https://github.com/filmil/bazel_elfutils"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;1.0.8&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/1.0.8">1.0.8</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00221.0.8\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;1.0.5&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/1.0.5">1.0.5</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00221.0.5\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;1.0.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/1.0.4">1.0.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00221.0.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;1.0.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/1.0.2">1.0.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00221.0.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;1.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/1.0.1">1.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00221.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;1.0.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/1.0.0">1.0.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.8&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.8">0.4.8</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.8\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.7&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.7">0.4.7</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.7\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.6&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.6">0.4.6</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.6\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.5&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.5">0.4.5</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.5\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.4">0.4.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.3">0.4.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.2">0.4.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.18&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.18">0.4.18</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.18\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.11&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.11">0.4.11</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.11\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.10&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.10">0.4.10</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.10\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.1">0.4.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.3.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.3.2">0.3.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.3.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.2.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.2.0">0.2.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.2.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.1.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.1.4">0.1.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.1.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.1.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.1.3">0.1.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.1.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.1.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.1.1">0.1.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.1.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.1.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.1.0">0.1.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.1.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.0.1">0.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>gcc_toolchain</code> (0.9.0)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+
+                                    <li>
+                                        <code>platforms</code> (1.0.0)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+
+                                    <li>
+                                        <code>rules_cc</code> (0.2.14)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_foreign_cc</code> (0.15.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_m4</code> (0.3)
+
+                                    </li>
+
+                                    <li>
+                                        <code>zlib</code> (1.3.1.bcr.7)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://github.com/filmil/bazel_elfutils">https://github.com/filmil/bazel_elfutils</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/bazel_elfutils">github:filmil/bazel_elfutils</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							fbzl
+							<a href="#ZgotmplZ"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fbzl&#34;, version = &#34;0.0.5&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fbzl/0.0.5">0.0.5</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fbzl\u0022, version = \u00220.0.5\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fbzl&#34;, version = &#34;0.0.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fbzl/0.0.3">0.0.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fbzl\u0022, version = \u00220.0.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fbzl&#34;, version = &#34;0.0.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fbzl/0.0.2">0.0.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fbzl\u0022, version = \u00220.0.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fbzl&#34;, version = &#34;0.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fbzl/0.0.1">0.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fbzl\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>bazel_lib</code> (3.2.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>bazel_skylib_gazelle_plugin</code> (1.8.2)
+
+                                    </li>
+
+                                    <li>
+                                        <code>buildifier_prebuilt</code> (8.2.0.2)
+
+                                    </li>
+
+                                    <li>
+                                        <code>gazelle</code> (0.47.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>protobuf</code> (33.4)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_pkg</code> (1.1.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>stardoc</code> (0.8.1)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="#ZgotmplZ">https.://github.com/filmil/fbzl</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/fbzl">github:filmil/fbzl</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							fshlib
+							<a href="https://github.com/filmil/fshlib"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.2.6&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.2.6">0.2.6</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.2.6\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.2.5&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.2.5">0.2.5</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.2.5\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.2.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.2.4">0.2.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.2.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.2.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.2.3">0.2.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.2.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.2.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.2.2">0.2.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.2.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.2.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.2.0">0.2.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.2.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.9&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.9">0.1.9</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.9\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.8&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.8">0.1.8</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.8\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.6&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.6">0.1.6</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.6\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.5&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.5">0.1.5</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.5\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.4">0.1.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.3">0.1.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.2">0.1.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.1">0.1.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.0.1">0.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://github.com/filmil/fshlib">https://github.com/filmil/fshlib</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/fshlib">github:filmil/fshlib</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							futility
+							<a href="https://github.com/filmil/futility"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.9&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.9">0.3.9</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.9\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.6&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.6">0.3.6</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.6\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.5&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.5">0.3.5</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.5\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.4">0.3.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.2">0.3.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.13&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.13">0.3.13</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.13\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.10&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.10">0.3.10</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.10\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.1">0.3.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.0">0.3.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.2.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.2.3">0.2.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.2.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.2.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.2.2">0.2.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.2.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.2.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.2.1">0.2.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.2.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.2.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.2.0">0.2.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.2.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.1.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.1.0">0.1.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.1.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>buildifier_prebuilt</code> (8.2.0.2)
+
+                                    </li>
+
+                                    <li>
+                                        <code>gazelle</code> (0.47.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_go</code> (0.57.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_multitool</code> (1.9.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_pkg</code> (1.0.1)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://github.com/filmil/futility">https://github.com/filmil/futility</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/futility">github:filmil/futility</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							gotopt2
+							<a href="https://github.com/filmil/gotopt2"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;gotopt2&#34;, version = &#34;2.3.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/gotopt2/2.3.3">2.3.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022gotopt2\u0022, version = \u00222.3.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;gotopt2&#34;, version = &#34;2.2.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/gotopt2/2.2.4">2.2.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022gotopt2\u0022, version = \u00222.2.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;gotopt2&#34;, version = &#34;2.2.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/gotopt2/2.2.2">2.2.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022gotopt2\u0022, version = \u00222.2.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;gotopt2&#34;, version = &#34;2.2.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/gotopt2/2.2.1">2.2.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022gotopt2\u0022, version = \u00222.2.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;gotopt2&#34;, version = &#34;2.2.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/gotopt2/2.2.0">2.2.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022gotopt2\u0022, version = \u00222.2.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;gotopt2&#34;, version = &#34;2.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/gotopt2/2.0.1">2.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022gotopt2\u0022, version = \u00222.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>bazel_bats</code> (0.37.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>buildifier_prebuilt</code> (7.3.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>gazelle</code> (0.42.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_go</code> (0.60.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_multitool</code> (1.9.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_pkg</code> (1.0.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://github.com/filmil/gotopt2">https://github.com/filmil/gotopt2</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/gotopt2">github:filmil/gotopt2</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							graphviz
+							<a href="https://github.com/filmil/bazel_graphviz_foreign"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;graphviz&#34;, version = &#34;0.0.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/graphviz/0.0.2">0.0.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022graphviz\u0022, version = \u00220.0.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>hermetic_cc_toolchain</code> (3.1.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_cc</code> (0.2.8)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_foreign_cc</code> (0.15.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>zlib_foreign</code> (0.0.1)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://github.com/filmil/bazel_graphviz_foreign">https://github.com/filmil/bazel_graphviz_foreign</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/bazel_graphviz_foreign">github:filmil/bazel_graphviz_foreign</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							graphviz_foreign
+							<a href="https://github.com/filmil/bazel_graphviz_foreign"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;graphviz_foreign&#34;, version = &#34;0.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/graphviz_foreign/0.0.1">0.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022graphviz_foreign\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>hermetic_cc_toolchain</code> (3.1.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_cc</code> (0.2.8)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_foreign_cc</code> (0.15.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>zlib_foreign</code> (0.0.1)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://github.com/filmil/bazel_graphviz_foreign">https://github.com/filmil/bazel_graphviz_foreign</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/bazel_graphviz_foreign">github:filmil/bazel_graphviz_foreign</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							hello_foreign
+							<a href="https://github.com/filmil/bazel_hello_foreign"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.6&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.6">0.0.6</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.6\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.5&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.5">0.0.5</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.5\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.4">0.0.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.24&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.24">0.0.24</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.24\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.21&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.21">0.0.21</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.21\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.19&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.19">0.0.19</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.19\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.15&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.15">0.0.15</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.15\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.1">0.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>hermetic_cc_toolchain</code> (3.1.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_cc</code> (0.2.8)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_foreign_cc</code> (0.15.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>zlib_foreign</code> (0.0.1)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://github.com/filmil/bazel_hello_foreign">https://github.com/filmil/bazel_hello_foreign</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/bazel_hello_foreign">github:filmil/bazel_hello_foreign</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							libzstd
+							<a href="https://github.com/filmil/bazel_elfutils"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;libzstd&#34;, version = &#34;0.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/libzstd/0.0.1">0.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022libzstd\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>hermetic_cc_toolchain</code> (3.1.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_cc</code> (0.2.8)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_foreign_cc</code> (0.15.1)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://github.com/filmil/bazel_elfutils">https://github.com/filmil/bazel_elfutils</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/bazel_elfutils">github:filmil/bazel_elfutils</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							libzstd_foreign
+							<a href="https://github.com/filmil/bazel_libzstd"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;libzstd_foreign&#34;, version = &#34;0.0.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/libzstd_foreign/0.0.3">0.0.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022libzstd_foreign\u0022, version = \u00220.0.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;libzstd_foreign&#34;, version = &#34;0.0.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/libzstd_foreign/0.0.2">0.0.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022libzstd_foreign\u0022, version = \u00220.0.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>hermetic_cc_toolchain</code> (3.1.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_cc</code> (0.2.8)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_foreign_cc</code> (0.15.1)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://github.com/filmil/bazel_libzstd">https://github.com/filmil/bazel_libzstd</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/bazel_libzstd">github:filmil/bazel_libzstd</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							lit2md
+							<a href="#ZgotmplZ"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.2.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.2.2">1.2.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.2.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.2.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.2.1">1.2.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.2.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.2.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.2.0">1.2.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.2.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.9&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.9">1.1.9</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.9\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.7&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.7">1.1.7</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.7\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.6&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.6">1.1.6</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.6\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.4">1.1.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.3">1.1.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.10&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.10">1.1.10</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.10\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.1">1.1.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.0">1.1.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.0.1">1.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.0.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.0.0">1.0.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;0.2.9&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/0.2.9">0.2.9</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00220.2.9\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;0.2.8&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/0.2.8">0.2.8</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00220.2.8\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;0.2.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/0.2.3">0.2.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00220.2.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;0.2.10&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/0.2.10">0.2.10</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00220.2.10\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;0.1.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/0.1.1">0.1.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00220.1.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>aspect_bazel_lib</code> (2.21.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>bazel_lib</code> (3.0.0)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+
+                                    <li>
+                                        <code>bazel_skylib</code> (1.8.2)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+
+                                    <li>
+                                        <code>bazel_skylib_gazelle_plugin</code> (1.8.2)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+
+                                    <li>
+                                        <code>buildifier_prebuilt</code> (8.2.0.2)
+
+                                    </li>
+
+                                    <li>
+                                        <code>gazelle</code> (0.47.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>protobuf</code> (33.4)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+
+                                    <li>
+                                        <code>rules_go</code> (0.59.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_multitool</code> (1.9.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_pkg</code> (1.1.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>stardoc</code> (0.8.1)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="#ZgotmplZ">https.://github.com/filmil/lit2md</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/lit2md">github:filmil/lit2md</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							rules_bid
+							<a href="https://hdlfactory.com/post/2025/02/11/bazel-rules-for-build-in-docker-or-bid/"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.2.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.2.2">2.2.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.2.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.2.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.2.1">2.2.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.2.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.2.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.2.0">2.2.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.2.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.1.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.1.2">2.1.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.1.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.1.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.1.1">2.1.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.1.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.1.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.1.0">2.1.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.1.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.0.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.0.3">2.0.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.0.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.0.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.0.2">2.0.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.0.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.0.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.0.0">2.0.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.0.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>aspect_bazel_lib</code> (2.22.5)
+
+                                    </li>
+
+                                    <li>
+                                        <code>bazel_lib</code> (3.3.1)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+
+                                    <li>
+                                        <code>bazel_skylib</code> (1.9.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>bazel_skylib_gazelle_plugin</code> (1.9.0)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+
+                                    <li>
+                                        <code>buildifier_prebuilt</code> (8.5.1.2)
+
+                                    </li>
+
+                                    <li>
+                                        <code>fshlib</code> (0.2.6)
+
+                                    </li>
+
+                                    <li>
+                                        <code>gazelle</code> (0.51.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>protobuf</code> (34.1)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+
+                                    <li>
+                                        <code>rules_go</code> (0.60.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_multitool</code> (1.11.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_pkg</code> (1.2.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_shell</code> (0.8.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>stardoc</code> (0.8.1)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://hdlfactory.com/post/2025/02/11/bazel-rules-for-build-in-docker-or-bid/">https://hdlfactory.com/post/2025/02/11/bazel-rules-for-build-in-docker-or-bid/</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/bazel-rules-bid">github:filmil/bazel-rules-bid</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							rules_bt
+							<a href="https://www.hdlfactory.com"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.6&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.6">1.2.6</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.6\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.4">1.2.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.3">1.2.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.2">1.2.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.18&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.18">1.2.18</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.18\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.16&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.16">1.2.16</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.16\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.14&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.14">1.2.14</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.14\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.13&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.13">1.2.13</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.13\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.10&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.10">1.2.10</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.10\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.0">1.2.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.0.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.0.0">1.0.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>bazel_lib</code> (3.0.0)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+
+                                    <li>
+                                        <code>bazel_skylib</code> (1.8.2)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+
+                                    <li>
+                                        <code>bazel_skylib_gazelle_plugin</code> (1.8.2)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+
+                                    <li>
+                                        <code>gazelle</code> (0.45.0)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+
+                                    <li>
+                                        <code>rules_multitool</code> (1.8.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_pkg</code> (1.1.0)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://www.hdlfactory.com">https://www.hdlfactory.com</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/bazel_rules_bt">github:filmil/bazel_rules_bt</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							rules_fusesoc
+							<a href="https://github.com/filmil/bazel_rules_fusesoc_2"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;1.0.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/1.0.2">1.0.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00221.0.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;1.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/1.0.1">1.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00221.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;1.0.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/1.0.0">1.0.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.9.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.9.0">0.9.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.9.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.8.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.8.0">0.8.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.8.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.10.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.10.4">0.10.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.10.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.10.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.10.3">0.10.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.10.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.10.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.10.0">0.10.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.10.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.1.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.1.2">0.1.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.1.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.1.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.1.1">0.1.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.1.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.0.1">0.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>bazel_rules_bid</code> (1.2.2)
+
+                                    </li>
+
+                                    <li>
+                                        <code>gazelle</code> (0.47.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_go</code> (0.59.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_pkg</code> (1.2.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_python</code> (1.6.3)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_shar</code> (0.5.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://github.com/filmil/bazel_rules_fusesoc_2">https://github.com/filmil/bazel_rules_fusesoc_2</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/bazel_rules_fusesoc_2">github:filmil/bazel_rules_fusesoc_2</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							rules_nvc
+							<a href="https://github.com/filmil/bazel_rules_nvc"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.2.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.2.2">4.2.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.2.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.2.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.2.1">4.2.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.2.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.2.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.2.0">4.2.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.2.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.1.6&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.1.6">4.1.6</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.1.6\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.1.5&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.1.5">4.1.5</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.1.5\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.1.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.1.4">4.1.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.1.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.1.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.1.3">4.1.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.1.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.1.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.1.2">4.1.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.1.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.1.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.1.1">4.1.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.1.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.1.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.1.0">4.1.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.1.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.0.1">4.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.0.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.0.0">4.0.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.0.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;3.0.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/3.0.0">3.0.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00223.0.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;2.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/2.0.1">2.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00222.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;2.0.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/2.0.0">2.0.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00222.0.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;1.2.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/1.2.0">1.2.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00221.2.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;1.1.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/1.1.0">1.1.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00221.1.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;1.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/1.0.1">1.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00221.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;1.0.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/1.0.0">1.0.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>bazel_lib</code> (3.1.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>bazel_linux_packages</code> (0.3.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>bazel_skylib</code> (1.9.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>bazel_skylib_gazelle_plugin</code> (1.8.2)
+
+                                    </li>
+
+                                    <li>
+                                        <code>gazelle</code> (0.47.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>gotopt2</code> (2.2.2)
+
+                                    </li>
+
+                                    <li>
+                                        <code>platforms</code> (1.0.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>portable_cc_toolchain</code> (2025.12.16)
+
+                                    </li>
+
+                                    <li>
+                                        <code>protobuf</code> (34.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_android</code> (0.7.2)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_cc</code> (0.2.17)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_go</code> (0.60.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_shell</code> (0.8.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_verilator</code> (0.3.2)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_verilog</code> (1.1.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>stardoc</code> (0.8.1)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://github.com/filmil/bazel_rules_nvc">https://github.com/filmil/bazel_rules_nvc</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/bazel_rules_nvc">github:filmil/bazel_rules_nvc</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							rules_osvvm
+							<a href="https://github.com/filmil/bazel_rules_osvvm"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_osvvm&#34;, version = &#34;1.1.5&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_osvvm/1.1.5">1.1.5</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_osvvm\u0022, version = \u00221.1.5\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_osvvm&#34;, version = &#34;1.1.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_osvvm/1.1.4">1.1.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_osvvm\u0022, version = \u00221.1.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_osvvm&#34;, version = &#34;1.1.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_osvvm/1.1.3">1.1.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_osvvm\u0022, version = \u00221.1.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_osvvm&#34;, version = &#34;1.1.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_osvvm/1.1.2">1.1.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_osvvm\u0022, version = \u00221.1.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_osvvm&#34;, version = &#34;1.1.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_osvvm/1.1.1">1.1.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_osvvm\u0022, version = \u00221.1.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_osvvm&#34;, version = &#34;1.1.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_osvvm/1.1.0">1.1.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_osvvm\u0022, version = \u00221.1.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_osvvm&#34;, version = &#34;1.0.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_osvvm/1.0.0">1.0.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_osvvm\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>rules_nvc</code> (1.0.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>toolchains_llvm</code> (1.5.0)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://github.com/filmil/bazel_rules_osvvm">https://github.com/filmil/bazel_rules_osvvm</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/bazel_rules_osvvm">github:filmil/bazel_rules_osvvm</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							rules_shar
+							<a href="https://www.hdlfactory.com/post/2025/11/22/rules_shar-bazel-rules-for-creating-self-extracting-archives-shars/"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;1.0.6&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/1.0.6">1.0.6</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00221.0.6\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;1.0.5&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/1.0.5">1.0.5</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00221.0.5\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;1.0.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/1.0.4">1.0.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00221.0.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;1.0.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/1.0.3">1.0.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00221.0.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;1.0.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/1.0.2">1.0.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00221.0.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;1.0.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/1.0.0">1.0.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.5.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.5.4">0.5.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.5.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.5.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.5.2">0.5.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.5.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.5.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.5.1">0.5.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.5.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.5.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.5.0">0.5.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.5.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.4.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.4.2">0.4.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.4.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.4.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.4.1">0.4.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.4.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.4.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.4.0">0.4.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.4.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.3.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.3.2">0.3.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.3.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.3.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.3.1">0.3.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.3.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.3.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.3.0">0.3.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.3.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.2.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.2.1">0.2.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.2.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.2.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.2.0">0.2.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.2.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.1.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.1.2">0.1.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.1.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.1.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.1.1">0.1.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.1.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.1.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.1.0">0.1.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.1.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.0.1">0.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>rules_pkg</code> (1.2.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://www.hdlfactory.com/post/2025/11/22/rules_shar-bazel-rules-for-creating-self-extracting-archives-shars/">https://www.hdlfactory.com/post/2025/11/22/rules_shar-bazel-rules-for-creating-self-extracting-archives-shars/</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/rules_shar">github:filmil/rules_shar</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							rules_vivado
+							<a href="https://github.com/filmil/bazel_rules_vivado"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.5.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.5.0">3.5.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.5.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.4.5&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.4.5">3.4.5</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.4.5\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.4.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.4.4">3.4.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.4.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.4.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.4.3">3.4.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.4.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.4.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.4.2">3.4.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.4.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.4.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.4.1">3.4.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.4.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.4.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.4.0">3.4.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.4.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.3.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.3.1">3.3.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.3.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.3.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.3.0">3.3.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.3.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.2.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.2.0">3.2.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.2.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.1.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.1.0">3.1.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.1.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.0.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.0.2">3.0.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.0.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.0.1">3.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>bazel_lib</code> (3.2.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>bazel_skylib</code> (1.8.2)
+
+                                    </li>
+
+                                    <li>
+                                        <code>bazel_skylib_gazelle_plugin</code> (1.8.2)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+
+                                    <li>
+                                        <code>buildifier_prebuilt</code> (8.2.0.2)
+
+                                    </li>
+
+                                    <li>
+                                        <code>fshlib</code> (0.2.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>gazelle</code> (0.47.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>gotopt2</code> (2.2.4)
+
+                                    </li>
+
+                                    <li>
+                                        <code>protobuf</code> (33.4)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_bid</code> (2.2.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_go</code> (0.59.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>stardoc</code> (0.8.1)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://github.com/filmil/bazel_rules_vivado">https://github.com/filmil/bazel_rules_vivado</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/bazel_rules_vivado">github:filmil/bazel_rules_vivado</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							rules_vunit
+							<a href="https://github.com/filmil/bazel_rules_vunit"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vunit&#34;, version = &#34;1.2.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vunit/1.2.2">1.2.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vunit\u0022, version = \u00221.2.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vunit&#34;, version = &#34;1.2.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vunit/1.2.1">1.2.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vunit\u0022, version = \u00221.2.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vunit&#34;, version = &#34;1.2.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vunit/1.2.0">1.2.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vunit\u0022, version = \u00221.2.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vunit&#34;, version = &#34;1.1.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vunit/1.1.0">1.1.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vunit\u0022, version = \u00221.1.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vunit&#34;, version = &#34;1.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vunit/1.0.1">1.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vunit\u0022, version = \u00221.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vunit&#34;, version = &#34;1.0.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vunit/1.0.0">1.0.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vunit\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vunit&#34;, version = &#34;0.0.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vunit/0.0.2">0.0.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vunit\u0022, version = \u00220.0.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>rules_nvc</code> (1.2.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_osvvm</code> (1.1.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>toolchains_llvm</code> (1.5.0)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://github.com/filmil/bazel_rules_vunit">https://github.com/filmil/bazel_rules_vunit</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/bazel_rules_vunit">github:filmil/bazel_rules_vunit</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							upspin
+							<a href="https://github.com/filmil/upspin"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;43.0.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/43.0.2">43.0.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002243.0.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;43.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/43.0.1">43.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002243.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;43.0.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/43.0.0">43.0.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002243.0.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;42.1.9&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/42.1.9">42.1.9</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002242.1.9\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;42.1.8&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/42.1.8">42.1.8</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002242.1.8\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;42.1.6&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/42.1.6">42.1.6</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002242.1.6\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;42.1.5&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/42.1.5">42.1.5</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002242.1.5\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;42.1.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/42.1.4">42.1.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002242.1.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>gazelle</code> (0.50.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>protobuf</code> (34.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_android</code> (0.7.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_go</code> (0.60.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_oci</code> (2.3.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_pkg</code> (1.0.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_proto</code> (7.1.0)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://github.com/filmil/upspin">https://github.com/filmil/upspin</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/upspin">github:filmil/upspin</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							upspin_drive
+							<a href="https://github.com/filmil/upspin-gdrive"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin_drive&#34;, version = &#34;42.1.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin_drive/42.1.1">42.1.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin_drive\u0022, version = \u002242.1.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin_drive&#34;, version = &#34;0.1.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin_drive/0.1.2">0.1.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin_drive\u0022, version = \u00220.1.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>bazel_lib</code> (3.0.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>gazelle</code> (0.50.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>platforms</code> (1.0.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_go</code> (0.60.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_oci</code> (2.2.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_pkg</code> (1.0.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>upspin</code> (43.0.1)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://github.com/filmil/upspin-gdrive">https://github.com/filmil/upspin-gdrive</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/upspin-gdrive">github:filmil/upspin-gdrive</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							vhdl_ls_gen
+							<a href="https://github.com/filmil/bazel_vhdl_ls_gen"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.3.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.3.0">0.3.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.3.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.2.6&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.2.6">0.2.6</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.2.6\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.2.5&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.2.5">0.2.5</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.2.5\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.2.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.2.4">0.2.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.2.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.2.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.2.3">0.2.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.2.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.2.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.2.1">0.2.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.2.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.2.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.2.0">0.2.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.2.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.1.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.1.2">0.1.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.1.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.1.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.1.1">0.1.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.1.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.1.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.1.0">0.1.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.1.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.0.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.0.2">0.0.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.0.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.0.1">0.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>bazel_lib</code> (3.1.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>bazel_skylib</code> (1.8.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://github.com/filmil/bazel_vhdl_ls_gen">https://github.com/filmil/bazel_vhdl_ls_gen</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/bazel_vhdl_ls_gen">github:filmil/bazel_vhdl_ls_gen</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							xrootfs
+							<a href="https://github.com/filmil/xrootfs"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.9&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.9">0.2.9</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.9\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.3">0.2.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.21&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.21">0.2.21</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.21\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.2">0.2.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.17&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.17">0.2.17</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.17\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.11&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.11">0.2.11</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.11\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.1">0.2.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.0">0.2.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.1.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.1.4">0.1.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.1.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.1.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.1.3">0.1.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.1.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.0.4&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.0.4">0.0.4</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.0.4\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.0.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.0.3">0.0.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.0.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>buildifier_prebuilt</code> (8.2.0.2)
+
+                                    </li>
+
+                                    <li>
+                                        <code>gazelle</code> (0.45.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_go</code> (0.57.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_multitool</code> (1.9.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_pkg</code> (1.0.1)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://github.com/filmil/xrootfs">https://github.com/filmil/xrootfs</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/xrootfs">github:filmil/xrootfs</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="col-md-4 mb-4 module-card">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							zlib_foreign
+							<a href="https://github.com/filmil/bazel_zlib_foreign"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <p class="card-text">
+                            <strong>Versions:</strong>
+
+
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;zlib_foreign&#34;, version = &#34;0.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/zlib_foreign/0.0.1">0.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022zlib_foreign\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+
+
+                        </p>
+
+
+
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+
+                                    <li>
+                                        <code>hermetic_cc_toolchain</code> (3.1.0)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_cc</code> (0.2.8)
+
+                                    </li>
+
+                                    <li>
+                                        <code>rules_foreign_cc</code> (0.15.1)
+
+                                    </li>
+
+                                </ul>
+                                </details>
+
+
+                        <p class="card-text"><a href="https://github.com/filmil/bazel_zlib_foreign">https://github.com/filmil/bazel_zlib_foreign</a></p>
+                        <p class="card-text">
+
+							<a href="https://github.com/filmil/bazel_zlib_foreign">github:filmil/bazel_zlib_foreign</a>
+                        </p>
+                    </div>
+                </div>
+            </div>
+
+        </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
+    <script>
+        const searchInput = document.getElementById('searchInput');
+        const moduleCards = document.querySelectorAll('.module-card');
+
+        searchInput.addEventListener('keyup', (event) => {
+            const filter = event.target.value.toLowerCase();
+            moduleCards.forEach(card => {
+                const title = card.querySelector('.card-title').textContent.toLowerCase();
+                if (title.includes(filter)) {
+                    card.style.display = '';
+                } else {
+                    card.style.display = 'none';
+                }
+            });
+        });
+
+        const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
+        const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl));
+
+        function copyToClipboard(text) {
+            navigator.clipboard.writeText(text).then(function() {
+
+            }, function() {
+
+                alert('Failed to copy');
+            });
+        }
+    </script>
+    <footer class="text-center mt-4 py-3">
+        <p>&copy; 2025-present Filip Filmar. All rights reserved.</p>
+        <p><small>This page was generated by an automated coding assistant.</small></p>
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
Modifies the HTML template in `cmd/generate/main.go` to use HTML5 `<details>` and `<summary>` elements to create a collapsible "zippy" for the "Dependencies (Latest)" section. This matches the behavior requested in #541.

---
*PR created automatically by Jules for task [16920597066772420261](https://jules.google.com/task/16920597066772420261) started by @filmil*