### PR TITLE
Fix #546: Hide older versions behind details block

### DIFF
--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -388,21 +388,44 @@ const htmlTemplate = `
 							{{$module.Name}}
 							<a href="{{$module.Metadata.Homepage}}"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
-                            {{range $i, $v := $module.Versions}}
-                                {{if isYanked $v.Name $module.Metadata}}
-                                    <span class="me-2"><del>{{$v.Name}}</del></span>
+                            {{if gt (len $module.Versions) 0}}
+                                {{$latest := index $module.Versions 0}}
+                                {{if isYanked $latest.Name $module.Metadata}}
+                                    <span class="me-2"><del>{{$latest.Name}}</del></span>
                                 {{else}}
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ bazelDep $module.Name $v.Name }}">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/{{$module.Name}}/{{$v.Name}}">{{$v.Name}}</a>
-                                        <a href="#" onclick="copyToClipboard('{{ bazelDep $module.Name $v.Name }}'); return false;">
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ bazelDep $module.Name $latest.Name }}">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/{{$module.Name}}/{{$latest.Name}}">{{$latest.Name}}</a>
+                                        <a href="#" onclick="copyToClipboard('{{ bazelDep $module.Name $latest.Name }}'); return false;">
                                             <i class="bi bi-clipboard"></i>
                                         </a>
                                     </span>
                                 {{end}}
+
+                                {{if gt (len $module.Versions) 1}}
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        {{range $i, $v := $module.Versions}}
+                                            {{if gt $i 0}}
+                                                {{if isYanked $v.Name $module.Metadata}}
+                                                    <span class="me-2"><del>{{$v.Name}}</del></span>
+                                                {{else}}
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ bazelDep $module.Name $v.Name }}">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/{{$module.Name}}/{{$v.Name}}">{{$v.Name}}</a>
+                                                        <a href="#" onclick="copyToClipboard('{{ bazelDep $module.Name $v.Name }}'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                {{end}}
+                                            {{end}}
+                                        {{end}}
+                                        </div>
+                                    </details>
+                                {{end}}
                             {{end}}
-                        </p>
+                        </div>
                         {{if gt (len $module.Versions) 0}}
                             {{$latest := index $module.Versions 0}}
                             {{if gt (len $latest.Dependencies) 0}}

--- a/index.html
+++ b/index.html
@@ -23,11 +23,98 @@
 
 	  gtag('config', 'G-BKGTF9GD1K');
 	</script>
+	<script>
+      function getPreferredTheme() {
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          return savedTheme;
+        }
+        return 'system';
+      }
+
+      function resolveTheme(theme) {
+        if (theme === 'system') {
+          const currentHour = new Date().getHours();
+          return (currentHour >= 19 || currentHour < 7) ? 'dark' : 'light';
+        }
+        return theme;
+      }
+
+      function updateThemeIcon(theme) {
+        const toggleBtn = document.getElementById('themeToggle');
+        if (toggleBtn) {
+          if (theme === 'light') {
+            toggleBtn.innerHTML = '<i class="bi bi-sun"></i>';
+          } else if (theme === 'dark') {
+            toggleBtn.innerHTML = '<i class="bi bi-moon-stars"></i>';
+          } else {
+            toggleBtn.innerHTML = '<i class="bi bi-circle-half"></i>';
+          }
+        }
+      }
+
+      function setTheme(theme) {
+        document.documentElement.setAttribute('data-bs-theme', resolveTheme(theme));
+        localStorage.setItem('theme', theme);
+        updateThemeIcon(theme);
+      }
+
+      setTheme(getPreferredTheme());
+
+      document.addEventListener('DOMContentLoaded', () => {
+        updateThemeIcon(getPreferredTheme());
+      });
+
+      function toggleTheme() {
+        const currentTheme = getPreferredTheme();
+        let newTheme;
+        if (currentTheme === 'system') {
+          newTheme = 'light';
+        } else if (currentTheme === 'light') {
+          newTheme = 'dark';
+        } else {
+          newTheme = 'system';
+        }
+        setTheme(newTheme);
+      }
+	</script>
+	<style>
+      [data-bs-theme="dark"] {
+        --bs-body-color: #e9ecef;
+        --bs-secondary-color: #adb5bd;
+        --bs-tertiary-color: #dee2e6;
+        --bs-link-color: #6ea8fe;
+        --bs-link-hover-color: #9ec5fe;
+      }
+      [data-bs-theme="dark"] .card-title {
+        color: #6ea8fe;
+      }
+      [data-bs-theme="dark"] .text-secondary {
+        color: #ced4da !important;
+      }
+      [data-bs-theme="dark"] .text-muted {
+        color: #adb5bd !important;
+      }
+      [data-bs-theme="dark"] code:not(pre code) {
+        background-color: var(--bs-tertiary-bg);
+        color: #e6edf3;
+      }
+      [data-bs-theme="dark"] blockquote {
+        background-color: var(--bs-tertiary-bg);
+        border-left-color: var(--bs-border-color);
+        color: var(--bs-secondary-color);
+      }
+	</style>
 </head>
 <body>
     <div class="container">
-		<h1 class="mt-5"><a href="https://www.hdlfactory.com">My</a> <a
-		href="https://bazel.build">Bazel</a> Registry</h1>
+		<div class="d-flex justify-content-between align-items-center mt-5">
+			<h1 class="mb-0"><a href="https://www.hdlfactory.com">My</a> <a
+			href="https://bazel.build">Bazel</a> Registry</h1>
+			<button class="btn btn-outline-secondary" onclick="toggleTheme()" id="themeToggle" title="Toggle theme">
+				<i class="bi bi-circle-half"></i>
+			</button>
+		</div>
 
 		<p>These modules are published in <a
 		href="https://github.com/filmil/bazel-registry">my private bazel
@@ -48,8 +135,9 @@
 							bazel-go-basic
 							<a href="https://github.com/filmil/bazel-go-basic"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel-go-basic&#34;, version = &#34;0.2.21&#34;)">
@@ -61,33 +149,50 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel-go-basic&#34;, version = &#34;0.2.20&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel-go-basic/0.2.20">0.2.20</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel-go-basic\u0022, version = \u00220.2.20\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel-go-basic&#34;, version = &#34;0.2.19&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel-go-basic/0.2.19">0.2.19</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel-go-basic\u0022, version = \u00220.2.19\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel-go-basic&#34;, version = &#34;0.2.20&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel-go-basic/0.2.20">0.2.20</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel-go-basic\u0022, version = \u00220.2.20\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel-go-basic&#34;, version = &#34;0.1.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel-go-basic/0.1.4">0.1.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel-go-basic\u0022, version = \u00220.1.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
-                        </p>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel-go-basic&#34;, version = &#34;0.2.19&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel-go-basic/0.2.19">0.2.19</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel-go-basic\u0022, version = \u00220.2.19\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel-go-basic&#34;, version = &#34;0.1.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel-go-basic/0.1.4">0.1.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel-go-basic\u0022, version = \u00220.1.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -135,8 +240,9 @@
 							bazel_bats
 							<a href="https://www.hdlfactory.com"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_bats&#34;, version = &#34;0.38.23&#34;)">
@@ -148,51 +254,72 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_bats&#34;, version = &#34;0.37.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_bats/0.37.1">0.37.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_bats\u0022, version = \u00220.37.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_bats&#34;, version = &#34;0.37.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_bats/0.37.0">0.37.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_bats\u0022, version = \u00220.37.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_bats&#34;, version = &#34;0.37.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_bats/0.37.1">0.37.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_bats\u0022, version = \u00220.37.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_bats&#34;, version = &#34;0.36.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_bats/0.36.4">0.36.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_bats\u0022, version = \u00220.36.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_bats&#34;, version = &#34;0.37.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_bats/0.37.0">0.37.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_bats\u0022, version = \u00220.37.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_bats&#34;, version = &#34;0.36.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_bats/0.36.2">0.36.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_bats\u0022, version = \u00220.36.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_bats&#34;, version = &#34;0.36.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_bats/0.36.4">0.36.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_bats\u0022, version = \u00220.36.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_bats&#34;, version = &#34;0.36.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_bats/0.36.0">0.36.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_bats\u0022, version = \u00220.36.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
-                        </p>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_bats&#34;, version = &#34;0.36.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_bats/0.36.2">0.36.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_bats\u0022, version = \u00220.36.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_bats&#34;, version = &#34;0.36.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_bats/0.36.0">0.36.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_bats\u0022, version = \u00220.36.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -240,8 +367,9 @@
 							bazel_ebook
 							<a href="https://hdlfactory.com/post/2025/02/04/typeset-your-own-ebooks-easily-with-bazel-ebook"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;2.0.15&#34;)">
@@ -253,105 +381,138 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;1.0.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/1.0.0">1.0.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00221.0.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.2.5&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.2.5">0.2.5</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.2.5\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;1.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/1.0.0">1.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.2.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.2.4">0.2.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.2.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.2.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.2.5">0.2.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.2.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.2.3&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.2.3">0.2.3</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.2.3\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.2.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.2.4">0.2.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.2.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.2.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.2.2">0.2.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.2.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.2.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.2.3">0.2.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.2.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.2.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.2.1">0.2.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.2.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.2.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.2.2">0.2.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.2.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.1.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.1.1">0.1.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.1.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.2.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.2.1">0.2.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.2.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.0.5&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.0.5">0.0.5</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.0.5\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.1.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.1.1">0.1.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.1.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.0.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.0.4">0.0.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.0.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.0.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.0.5">0.0.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.0.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.0.3&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.0.3">0.0.3</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.0.3\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.0.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.0.4">0.0.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.0.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.0.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.0.1">0.0.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.0.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
-                        </p>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.0.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.0.3">0.0.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.0.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.0.1">0.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -439,8 +600,9 @@
 							bazel_rootfs
 							<a href="https://hdlfactory.com/tags/bazel-modules"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rootfs&#34;, version = &#34;1.0.3&#34;)">
@@ -452,51 +614,72 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rootfs&#34;, version = &#34;1.0.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rootfs/1.0.2">1.0.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rootfs\u0022, version = \u00221.0.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rootfs&#34;, version = &#34;1.0.18&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rootfs/1.0.18">1.0.18</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rootfs\u0022, version = \u00221.0.18\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rootfs&#34;, version = &#34;1.0.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rootfs/1.0.2">1.0.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rootfs\u0022, version = \u00221.0.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rootfs&#34;, version = &#34;1.0.12&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rootfs/1.0.12">1.0.12</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rootfs\u0022, version = \u00221.0.12\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rootfs&#34;, version = &#34;1.0.18&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rootfs/1.0.18">1.0.18</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rootfs\u0022, version = \u00221.0.18\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rootfs&#34;, version = &#34;1.0.10&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rootfs/1.0.10">1.0.10</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rootfs\u0022, version = \u00221.0.10\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rootfs&#34;, version = &#34;1.0.12&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rootfs/1.0.12">1.0.12</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rootfs\u0022, version = \u00221.0.12\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rootfs&#34;, version = &#34;1.0.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rootfs/1.0.1">1.0.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rootfs\u0022, version = \u00221.0.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
-                        </p>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rootfs&#34;, version = &#34;1.0.10&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rootfs/1.0.10">1.0.10</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rootfs\u0022, version = \u00221.0.10\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rootfs&#34;, version = &#34;1.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rootfs/1.0.1">1.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rootfs\u0022, version = \u00221.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -564,8 +747,9 @@
 							bazel_rules_bid
 							<a href="https://hdlfactory.com/post/2025/02/11/bazel-rules-for-build-in-docker-or-bid/"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.4.0&#34;)">
@@ -577,204 +761,259 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.3.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.3.0">1.3.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.3.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.2.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.2.4">1.2.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.2.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.3.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.3.0">1.3.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.3.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.2.3&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.2.3">1.2.3</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.2.3\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.2.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.2.2">1.2.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.2.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.2.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.2.4">1.2.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.2.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.2.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.2.1">1.2.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.2.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.2.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.2.0">1.2.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.2.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.2.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.2.3">1.2.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.2.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.1.3&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.1.3">1.1.3</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.1.3\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.2.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.2.2">1.2.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.2.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.1.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.1.2">1.1.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.1.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.1.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.1.1">1.1.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.1.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.2.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.2.1">1.2.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.2.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.1.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.1.0">1.1.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.1.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.0.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.0.4">1.0.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.0.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.2.0">1.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.0.3&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.0.3">1.0.3</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.0.3\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.1.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.1.3">1.1.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.1.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.0.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.0.2">1.0.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.0.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.0.10&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.0.10">1.0.10</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.0.10\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.1.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.1.2">1.1.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.1.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.0.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.0.0">1.0.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.0.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;0.3.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/0.3.0">0.3.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00220.3.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.1.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.1.1">1.1.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.1.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;0.2.5&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/0.2.5">0.2.5</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00220.2.5\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.1.0">1.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;0.2.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/0.2.4">0.2.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00220.2.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;0.2.3&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/0.2.3">0.2.3</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00220.2.3\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.0.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.0.4">1.0.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.0.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;0.2.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/0.2.2">0.2.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00220.2.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;0.2.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/0.2.1">0.2.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00220.2.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.0.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.0.3">1.0.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.0.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;0.2.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/0.2.0">0.2.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00220.2.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
-                        </p>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.0.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.0.2">1.0.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.0.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.0.10&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.0.10">1.0.10</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.0.10\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.0.0">1.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;0.3.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/0.3.0">0.3.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00220.3.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;0.2.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/0.2.5">0.2.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00220.2.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;0.2.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/0.2.4">0.2.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00220.2.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;0.2.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/0.2.3">0.2.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00220.2.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;0.2.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/0.2.2">0.2.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00220.2.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;0.2.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/0.2.1">0.2.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00220.2.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;0.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/0.2.0">0.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00220.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -832,8 +1071,9 @@
 							bazel_rules_bt
 							<a href="https://www.hdlfactory.com"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bt&#34;, version = &#34;0.0.3&#34;)">
@@ -845,15 +1085,28 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bt&#34;, version = &#34;0.0.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bt/0.0.1">0.0.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bt\u0022, version = \u00220.0.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
-                        </p>
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bt&#34;, version = &#34;0.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bt/0.0.1">0.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bt\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -886,8 +1139,9 @@
 							bazel_rules_ghdl
 							<a href="https://github.com/filmil/bazel_rules_ghdl"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.7&#34;)">
@@ -899,141 +1153,182 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.6&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.6">0.1.6</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.6\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.5&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.5">0.1.5</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.5\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.6&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.6">0.1.6</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.6\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.4">0.1.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.5">0.1.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.3&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.3">0.1.3</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.3\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.4">0.1.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.24&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.24">0.1.24</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.24\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.3">0.1.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.21&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.21">0.1.21</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.21\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.24&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.24">0.1.24</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.24\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.19&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.19">0.1.19</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.19\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.21&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.21">0.1.21</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.21\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.17&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.17">0.1.17</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.17\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.19&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.19">0.1.19</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.19\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.15&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.15">0.1.15</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.15\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.17&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.17">0.1.17</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.17\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.13&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.13">0.1.13</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.13\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.15&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.15">0.1.15</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.15\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.12&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.12">0.1.12</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.12\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.13&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.13">0.1.13</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.13\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.10&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.10">0.1.10</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.10\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.12&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.12">0.1.12</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.12\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.1">0.1.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.10&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.10">0.1.10</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.10\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.0">0.1.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.1">0.1.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.0.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.0.1">0.0.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.0.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
-                        </p>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.0">0.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.0.1">0.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -1096,8 +1391,9 @@
 							bazel_rules_nvc
 							<a href="https://github.com/filmil/bazel_rules_nvc"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.5.2&#34;)">
@@ -1109,186 +1405,237 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.5.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.5.1">0.5.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.5.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.5.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.5.0">0.5.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.5.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.5.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.5.1">0.5.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.5.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.4.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.4.1">0.4.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.4.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.5.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.5.0">0.5.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.5.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.4.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.4.0">0.4.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.4.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.4.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.4.1">0.4.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.4.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.3.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.3.2">0.3.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.3.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.4.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.4.0">0.4.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.4.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.3.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.3.1">0.3.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.3.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.3.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.3.2">0.3.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.3.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.3.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.3.0">0.3.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.3.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.3.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.3.1">0.3.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.3.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.9&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.9">0.2.9</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.9\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.3.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.3.0">0.3.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.3.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.8&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.8">0.2.8</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.8\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.9&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.9">0.2.9</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.9\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.7&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.7">0.2.7</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.7\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.8&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.8">0.2.8</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.8\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.6&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.6">0.2.6</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.6\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.7&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.7">0.2.7</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.7\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.4">0.2.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.6&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.6">0.2.6</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.6\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.2">0.2.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.4">0.2.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.11&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.11">0.2.11</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.11\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.2">0.2.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.10&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.10">0.2.10</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.10\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.11&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.11">0.2.11</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.11\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.1">0.2.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.10&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.10">0.2.10</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.10\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.0">0.2.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.1">0.2.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.1.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.1.0">0.1.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.1.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.0">0.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.0.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.0.2">0.0.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.0.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.1.0">0.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.0.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.0.1">0.0.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.0.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
-                        </p>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.0.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.0.2">0.0.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.0.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.0.1">0.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -1391,8 +1738,9 @@
 							bazel_rules_osvvm
 							<a href="https://github.com/filmil/bazel_nvc_osvvm"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_osvvm&#34;, version = &#34;0.0.1&#34;)">
@@ -1403,7 +1751,9 @@
                                     </span>
 
 
-                        </p>
+
+
+                        </div>
 
 
 
@@ -1441,8 +1791,9 @@
 							bazel_rules_raylib
 							<a href="https://github.com/filmil/bazel_rules_raylib"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_raylib&#34;, version = &#34;0.0.7&#34;)">
@@ -1454,51 +1805,72 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_raylib&#34;, version = &#34;0.0.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_raylib/0.0.4">0.0.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_raylib\u0022, version = \u00220.0.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_raylib&#34;, version = &#34;0.0.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_raylib/0.0.2">0.0.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_raylib\u0022, version = \u00220.0.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_raylib&#34;, version = &#34;0.0.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_raylib/0.0.4">0.0.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_raylib\u0022, version = \u00220.0.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_raylib&#34;, version = &#34;0.0.19&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_raylib/0.0.19">0.0.19</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_raylib\u0022, version = \u00220.0.19\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_raylib&#34;, version = &#34;0.0.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_raylib/0.0.2">0.0.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_raylib\u0022, version = \u00220.0.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_raylib&#34;, version = &#34;0.0.16&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_raylib/0.0.16">0.0.16</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_raylib\u0022, version = \u00220.0.16\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_raylib&#34;, version = &#34;0.0.19&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_raylib/0.0.19">0.0.19</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_raylib\u0022, version = \u00220.0.19\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_raylib&#34;, version = &#34;0.0.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_raylib/0.0.1">0.0.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_raylib\u0022, version = \u00220.0.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
-                        </p>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_raylib&#34;, version = &#34;0.0.16&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_raylib/0.0.16">0.0.16</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_raylib\u0022, version = \u00220.0.16\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_raylib&#34;, version = &#34;0.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_raylib/0.0.1">0.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_raylib\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -1576,8 +1948,9 @@
 							bazel_rules_vivado
 							<a href="https://github.com/filmil/bazel_rules_vivado"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;3.0.0&#34;)">
@@ -1589,168 +1962,215 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;2.0.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/2.0.0">2.0.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00222.0.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;1.0.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/1.0.1">1.0.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00221.0.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;2.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/2.0.0">2.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00222.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;1.0.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/1.0.0">1.0.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00221.0.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;1.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/1.0.1">1.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00221.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.5.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.5.1">0.5.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.5.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;1.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/1.0.0">1.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.5.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.5.0">0.5.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.5.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.5.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.5.1">0.5.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.5.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.4.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.4.0">0.4.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.4.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.5.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.5.0">0.5.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.5.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.3.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.3.1">0.3.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.3.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.4.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.4.0">0.4.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.4.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.3.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.3.0">0.3.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.3.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.3.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.3.1">0.3.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.3.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.2.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.2.0">0.2.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.2.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.3.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.3.0">0.3.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.3.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.1.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.1.0">0.1.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.1.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.2.0">0.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.9&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.9">0.0.9</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.9\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.1.0">0.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.8&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.8">0.0.8</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.8\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.9&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.9">0.0.9</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.9\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.6&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.6">0.0.6</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.6\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.8&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.8">0.0.8</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.8\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.5&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.5">0.0.5</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.5\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.6&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.6">0.0.6</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.6\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.4">0.0.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.5">0.0.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.14&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.14">0.0.14</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.14\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.4">0.0.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.11&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.11">0.0.11</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.11\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.14&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.14">0.0.14</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.14\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.10&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.10">0.0.10</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.10\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
-                        </p>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.11&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.11">0.0.11</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.11\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.10&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.10">0.0.10</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.10\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -1813,8 +2233,9 @@
 							bazoekt
 							<a href="https://github.com/filmil/bazoekt"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazoekt&#34;, version = &#34;0.1.5&#34;)">
@@ -1826,42 +2247,61 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazoekt&#34;, version = &#34;0.1.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazoekt/0.1.4">0.1.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazoekt\u0022, version = \u00220.1.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazoekt&#34;, version = &#34;0.1.3&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazoekt/0.1.3">0.1.3</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazoekt\u0022, version = \u00220.1.3\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazoekt&#34;, version = &#34;0.1.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazoekt/0.1.4">0.1.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazoekt\u0022, version = \u00220.1.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazoekt&#34;, version = &#34;0.1.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazoekt/0.1.2">0.1.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazoekt\u0022, version = \u00220.1.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazoekt&#34;, version = &#34;0.1.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazoekt/0.1.3">0.1.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazoekt\u0022, version = \u00220.1.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazoekt&#34;, version = &#34;0.1.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazoekt/0.1.1">0.1.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazoekt\u0022, version = \u00220.1.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
-                        </p>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazoekt&#34;, version = &#34;0.1.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazoekt/0.1.2">0.1.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazoekt\u0022, version = \u00220.1.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazoekt&#34;, version = &#34;0.1.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazoekt/0.1.1">0.1.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazoekt\u0022, version = \u00220.1.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -1929,8 +2369,9 @@
 							elfutils
 							<a href="https://github.com/filmil/bazel_elfutils"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;1.0.8&#34;)">
@@ -1942,213 +2383,270 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;1.0.5&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/1.0.5">1.0.5</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00221.0.5\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;1.0.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/1.0.4">1.0.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00221.0.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;1.0.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/1.0.5">1.0.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00221.0.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;1.0.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/1.0.2">1.0.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00221.0.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;1.0.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/1.0.1">1.0.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00221.0.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;1.0.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/1.0.4">1.0.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00221.0.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;1.0.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/1.0.0">1.0.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00221.0.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.8&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.8">0.4.8</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.8\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;1.0.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/1.0.2">1.0.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00221.0.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.7&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.7">0.4.7</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.7\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;1.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/1.0.1">1.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00221.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.6&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.6">0.4.6</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.6\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.5&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.5">0.4.5</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.5\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;1.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/1.0.0">1.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.4">0.4.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.3&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.3">0.4.3</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.3\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.8&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.8">0.4.8</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.8\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.2">0.4.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.7&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.7">0.4.7</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.7\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.18&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.18">0.4.18</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.18\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.11&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.11">0.4.11</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.11\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.6&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.6">0.4.6</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.6\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.10&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.10">0.4.10</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.10\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.1">0.4.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.5">0.4.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.3.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.3.2">0.3.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.3.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.4">0.4.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.2.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.2.0">0.2.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.2.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.1.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.1.4">0.1.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.1.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.3">0.4.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.1.3&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.1.3">0.1.3</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.1.3\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.1.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.1.1">0.1.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.1.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.2">0.4.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.1.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.1.0">0.1.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.1.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.18&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.18">0.4.18</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.18\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.0.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.0.1">0.0.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.0.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
-                        </p>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.11&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.11">0.4.11</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.11\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.10&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.10">0.4.10</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.10\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.1">0.4.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.3.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.3.2">0.3.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.3.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.2.0">0.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.1.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.1.4">0.1.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.1.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.1.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.1.3">0.1.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.1.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.1.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.1.1">0.1.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.1.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.1.0">0.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.0.1">0.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -2206,8 +2704,9 @@
 							fbzl
 							<a href="#ZgotmplZ"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fbzl&#34;, version = &#34;0.0.5&#34;)">
@@ -2219,33 +2718,50 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fbzl&#34;, version = &#34;0.0.3&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fbzl/0.0.3">0.0.3</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fbzl\u0022, version = \u00220.0.3\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fbzl&#34;, version = &#34;0.0.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fbzl/0.0.2">0.0.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fbzl\u0022, version = \u00220.0.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fbzl&#34;, version = &#34;0.0.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fbzl/0.0.3">0.0.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fbzl\u0022, version = \u00220.0.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fbzl&#34;, version = &#34;0.0.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fbzl/0.0.1">0.0.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fbzl\u0022, version = \u00220.0.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
-                        </p>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fbzl&#34;, version = &#34;0.0.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fbzl/0.0.2">0.0.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fbzl\u0022, version = \u00220.0.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fbzl&#34;, version = &#34;0.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fbzl/0.0.1">0.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fbzl\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -2308,8 +2824,9 @@
 							fshlib
 							<a href="https://github.com/filmil/fshlib"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.2.6&#34;)">
@@ -2321,132 +2838,171 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.2.5&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.2.5">0.2.5</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.2.5\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.2.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.2.4">0.2.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.2.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.2.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.2.5">0.2.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.2.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.2.3&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.2.3">0.2.3</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.2.3\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.2.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.2.4">0.2.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.2.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.2.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.2.2">0.2.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.2.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.2.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.2.3">0.2.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.2.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.2.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.2.0">0.2.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.2.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.2.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.2.2">0.2.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.2.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.9&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.9">0.1.9</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.9\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.2.0">0.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.8&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.8">0.1.8</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.8\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.9&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.9">0.1.9</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.9\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.6&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.6">0.1.6</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.6\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.8&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.8">0.1.8</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.8\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.5&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.5">0.1.5</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.5\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.6&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.6">0.1.6</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.6\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.4">0.1.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.5">0.1.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.3&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.3">0.1.3</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.3\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.4">0.1.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.2">0.1.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.3">0.1.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.1">0.1.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.2">0.1.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.0.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.0.1">0.0.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.0.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
-                        </p>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.1">0.1.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.0.1">0.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -2479,8 +3035,9 @@
 							futility
 							<a href="https://github.com/filmil/futility"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.9&#34;)">
@@ -2492,123 +3049,160 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.6&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.6">0.3.6</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.6\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.5&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.5">0.3.5</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.5\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.6&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.6">0.3.6</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.6\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.4">0.3.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.5">0.3.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.2">0.3.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.4">0.3.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.13&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.13">0.3.13</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.13\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.2">0.3.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.10&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.10">0.3.10</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.10\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.13&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.13">0.3.13</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.13\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.1">0.3.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.10&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.10">0.3.10</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.10\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.0">0.3.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.1">0.3.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.2.3&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.2.3">0.2.3</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.2.3\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.0">0.3.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.2.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.2.2">0.2.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.2.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.2.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.2.3">0.2.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.2.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.2.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.2.1">0.2.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.2.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.2.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.2.2">0.2.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.2.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.2.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.2.0">0.2.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.2.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.2.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.2.1">0.2.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.2.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.1.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.1.0">0.1.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.1.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
-                        </p>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.2.0">0.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.1.0">0.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -2661,8 +3255,9 @@
 							gotopt2
 							<a href="https://github.com/filmil/gotopt2"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;gotopt2&#34;, version = &#34;2.3.3&#34;)">
@@ -2674,51 +3269,72 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;gotopt2&#34;, version = &#34;2.2.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/gotopt2/2.2.4">2.2.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022gotopt2\u0022, version = \u00222.2.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;gotopt2&#34;, version = &#34;2.2.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/gotopt2/2.2.2">2.2.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022gotopt2\u0022, version = \u00222.2.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;gotopt2&#34;, version = &#34;2.2.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/gotopt2/2.2.4">2.2.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022gotopt2\u0022, version = \u00222.2.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;gotopt2&#34;, version = &#34;2.2.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/gotopt2/2.2.1">2.2.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022gotopt2\u0022, version = \u00222.2.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;gotopt2&#34;, version = &#34;2.2.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/gotopt2/2.2.2">2.2.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022gotopt2\u0022, version = \u00222.2.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;gotopt2&#34;, version = &#34;2.2.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/gotopt2/2.2.0">2.2.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022gotopt2\u0022, version = \u00222.2.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;gotopt2&#34;, version = &#34;2.2.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/gotopt2/2.2.1">2.2.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022gotopt2\u0022, version = \u00222.2.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;gotopt2&#34;, version = &#34;2.0.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/gotopt2/2.0.1">2.0.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022gotopt2\u0022, version = \u00222.0.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
-                        </p>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;gotopt2&#34;, version = &#34;2.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/gotopt2/2.2.0">2.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022gotopt2\u0022, version = \u00222.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;gotopt2&#34;, version = &#34;2.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/gotopt2/2.0.1">2.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022gotopt2\u0022, version = \u00222.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -2781,8 +3397,9 @@
 							graphviz
 							<a href="https://github.com/filmil/bazel_graphviz_foreign"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;graphviz&#34;, version = &#34;0.0.2&#34;)">
@@ -2793,7 +3410,9 @@
                                     </span>
 
 
-                        </p>
+
+
+                        </div>
 
 
 
@@ -2846,8 +3465,9 @@
 							graphviz_foreign
 							<a href="https://github.com/filmil/bazel_graphviz_foreign"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;graphviz_foreign&#34;, version = &#34;0.0.1&#34;)">
@@ -2858,7 +3478,9 @@
                                     </span>
 
 
-                        </p>
+
+
+                        </div>
 
 
 
@@ -2911,8 +3533,9 @@
 							hello_foreign
 							<a href="https://github.com/filmil/bazel_hello_foreign"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.6&#34;)">
@@ -2924,69 +3547,94 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.5&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.5">0.0.5</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.5\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.4">0.0.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.5">0.0.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.24&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.24">0.0.24</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.24\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.4">0.0.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.21&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.21">0.0.21</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.21\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.24&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.24">0.0.24</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.24\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.19&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.19">0.0.19</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.19\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.21&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.21">0.0.21</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.21\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.15&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.15">0.0.15</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.15\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.19&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.19">0.0.19</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.19\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.1">0.0.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
-                        </p>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.15&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.15">0.0.15</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.15\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.1">0.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -3039,8 +3687,9 @@
 							libzstd
 							<a href="https://github.com/filmil/bazel_elfutils"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;libzstd&#34;, version = &#34;0.0.1&#34;)">
@@ -3051,7 +3700,9 @@
                                     </span>
 
 
-                        </p>
+
+
+                        </div>
 
 
 
@@ -3094,8 +3745,9 @@
 							libzstd_foreign
 							<a href="https://github.com/filmil/bazel_libzstd"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;libzstd_foreign&#34;, version = &#34;0.0.3&#34;)">
@@ -3107,15 +3759,28 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;libzstd_foreign&#34;, version = &#34;0.0.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/libzstd_foreign/0.0.2">0.0.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022libzstd_foreign\u0022, version = \u00220.0.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
-                        </p>
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;libzstd_foreign&#34;, version = &#34;0.0.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/libzstd_foreign/0.0.2">0.0.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022libzstd_foreign\u0022, version = \u00220.0.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -3158,8 +3823,9 @@
 							lit2md
 							<a href="#ZgotmplZ"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.2.2&#34;)">
@@ -3171,159 +3837,204 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.2.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.2.1">1.2.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.2.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.2.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.2.0">1.2.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.2.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.2.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.2.1">1.2.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.2.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.9&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.9">1.1.9</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.9\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.2.0">1.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.7&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.7">1.1.7</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.7\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.9&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.9">1.1.9</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.9\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.6&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.6">1.1.6</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.6\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.7&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.7">1.1.7</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.7\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.4">1.1.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.6&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.6">1.1.6</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.6\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.3&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.3">1.1.3</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.3\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.4">1.1.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.10&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.10">1.1.10</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.10\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.3">1.1.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.1">1.1.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.10&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.10">1.1.10</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.10\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.0">1.1.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.1">1.1.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.0.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.0.1">1.0.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.0.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.0">1.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.0.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.0.0">1.0.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.0.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.0.1">1.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;0.2.9&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/0.2.9">0.2.9</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00220.2.9\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.0.0">1.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;0.2.8&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/0.2.8">0.2.8</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00220.2.8\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;0.2.9&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/0.2.9">0.2.9</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00220.2.9\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;0.2.3&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/0.2.3">0.2.3</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00220.2.3\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;0.2.8&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/0.2.8">0.2.8</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00220.2.8\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;0.2.10&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/0.2.10">0.2.10</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00220.2.10\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;0.2.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/0.2.3">0.2.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00220.2.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;0.1.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/0.1.1">0.1.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00220.1.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
-                        </p>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;0.2.10&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/0.2.10">0.2.10</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00220.2.10\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;0.1.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/0.1.1">0.1.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00220.1.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -3406,8 +4117,9 @@
 							rules_bid
 							<a href="https://hdlfactory.com/post/2025/02/11/bazel-rules-for-build-in-docker-or-bid/"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.2.2&#34;)">
@@ -3419,78 +4131,105 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.2.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.2.1">2.2.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.2.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.2.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.2.0">2.2.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.2.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.2.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.2.1">2.2.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.2.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.1.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.1.2">2.1.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.1.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.2.0">2.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.1.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.1.1">2.1.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.1.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.1.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.1.2">2.1.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.1.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.1.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.1.0">2.1.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.1.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.1.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.1.1">2.1.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.1.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.0.3&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.0.3">2.0.3</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.0.3\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.1.0">2.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.0.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.0.2">2.0.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.0.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.0.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.0.3">2.0.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.0.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.0.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.0.0">2.0.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.0.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
-                        </p>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.0.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.0.2">2.0.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.0.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.0.0">2.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -3583,8 +4322,9 @@
 							rules_bt
 							<a href="https://www.hdlfactory.com"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.6&#34;)">
@@ -3596,96 +4336,127 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.4">1.2.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.3&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.3">1.2.3</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.3\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.4">1.2.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.2">1.2.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.3">1.2.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.18&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.18">1.2.18</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.18\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.2">1.2.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.16&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.16">1.2.16</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.16\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.18&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.18">1.2.18</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.18\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.14&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.14">1.2.14</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.14\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.16&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.16">1.2.16</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.16\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.13&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.13">1.2.13</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.13\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.14&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.14">1.2.14</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.14\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.10&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.10">1.2.10</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.10\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.13&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.13">1.2.13</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.13\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.0">1.2.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.10&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.10">1.2.10</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.10\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.0.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.0.0">1.0.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.0.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
-                        </p>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.0">1.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.0.0">1.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -3743,8 +4514,9 @@
 							rules_fusesoc
 							<a href="https://github.com/filmil/bazel_rules_fusesoc_2"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;1.0.2&#34;)">
@@ -3756,96 +4528,127 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;1.0.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/1.0.1">1.0.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00221.0.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;1.0.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/1.0.0">1.0.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00221.0.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;1.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/1.0.1">1.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00221.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.9.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.9.0">0.9.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.9.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;1.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/1.0.0">1.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.8.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.8.0">0.8.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.8.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.9.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.9.0">0.9.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.9.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.10.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.10.4">0.10.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.10.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.8.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.8.0">0.8.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.8.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.10.3&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.10.3">0.10.3</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.10.3\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.10.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.10.4">0.10.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.10.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.10.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.10.0">0.10.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.10.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.10.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.10.3">0.10.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.10.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.1.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.1.2">0.1.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.1.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.10.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.10.0">0.10.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.10.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.1.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.1.1">0.1.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.1.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.1.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.1.2">0.1.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.1.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.0.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.0.1">0.0.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.0.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
-                        </p>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.1.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.1.1">0.1.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.1.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.0.1">0.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -3908,8 +4711,9 @@
 							rules_nvc
 							<a href="https://github.com/filmil/bazel_rules_nvc"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.2.2&#34;)">
@@ -3921,168 +4725,215 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.2.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.2.1">4.2.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.2.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.2.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.2.0">4.2.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.2.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.2.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.2.1">4.2.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.2.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.1.6&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.1.6">4.1.6</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.1.6\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.2.0">4.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.1.5&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.1.5">4.1.5</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.1.5\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.1.6&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.1.6">4.1.6</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.1.6\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.1.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.1.4">4.1.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.1.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.1.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.1.5">4.1.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.1.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.1.3&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.1.3">4.1.3</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.1.3\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.1.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.1.4">4.1.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.1.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.1.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.1.2">4.1.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.1.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.1.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.1.3">4.1.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.1.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.1.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.1.1">4.1.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.1.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.1.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.1.2">4.1.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.1.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.1.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.1.0">4.1.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.1.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.1.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.1.1">4.1.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.1.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.0.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.0.1">4.0.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.0.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.1.0">4.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.0.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.0.0">4.0.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.0.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.0.1">4.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;3.0.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/3.0.0">3.0.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00223.0.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.0.0">4.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;2.0.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/2.0.1">2.0.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00222.0.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;3.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/3.0.0">3.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00223.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;2.0.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/2.0.0">2.0.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00222.0.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;2.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/2.0.1">2.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00222.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;1.2.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/1.2.0">1.2.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00221.2.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;2.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/2.0.0">2.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00222.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;1.1.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/1.1.0">1.1.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00221.1.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;1.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/1.2.0">1.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00221.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;1.0.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/1.0.1">1.0.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00221.0.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;1.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/1.1.0">1.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00221.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;1.0.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/1.0.0">1.0.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00221.0.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
-                        </p>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;1.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/1.0.1">1.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00221.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;1.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/1.0.0">1.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -4190,8 +5041,9 @@
 							rules_osvvm
 							<a href="https://github.com/filmil/bazel_rules_osvvm"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_osvvm&#34;, version = &#34;1.1.5&#34;)">
@@ -4203,60 +5055,83 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_osvvm&#34;, version = &#34;1.1.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_osvvm/1.1.4">1.1.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_osvvm\u0022, version = \u00221.1.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_osvvm&#34;, version = &#34;1.1.3&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_osvvm/1.1.3">1.1.3</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_osvvm\u0022, version = \u00221.1.3\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_osvvm&#34;, version = &#34;1.1.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_osvvm/1.1.4">1.1.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_osvvm\u0022, version = \u00221.1.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_osvvm&#34;, version = &#34;1.1.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_osvvm/1.1.2">1.1.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_osvvm\u0022, version = \u00221.1.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_osvvm&#34;, version = &#34;1.1.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_osvvm/1.1.3">1.1.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_osvvm\u0022, version = \u00221.1.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_osvvm&#34;, version = &#34;1.1.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_osvvm/1.1.1">1.1.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_osvvm\u0022, version = \u00221.1.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_osvvm&#34;, version = &#34;1.1.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_osvvm/1.1.2">1.1.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_osvvm\u0022, version = \u00221.1.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_osvvm&#34;, version = &#34;1.1.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_osvvm/1.1.0">1.1.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_osvvm\u0022, version = \u00221.1.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_osvvm&#34;, version = &#34;1.1.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_osvvm/1.1.1">1.1.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_osvvm\u0022, version = \u00221.1.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_osvvm&#34;, version = &#34;1.0.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_osvvm/1.0.0">1.0.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_osvvm\u0022, version = \u00221.0.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
-                        </p>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_osvvm&#34;, version = &#34;1.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_osvvm/1.1.0">1.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_osvvm\u0022, version = \u00221.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_osvvm&#34;, version = &#34;1.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_osvvm/1.0.0">1.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_osvvm\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -4299,8 +5174,9 @@
 							rules_shar
 							<a href="https://www.hdlfactory.com/post/2025/11/22/rules_shar-bazel-rules-for-creating-self-extracting-archives-shars/"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;1.0.6&#34;)">
@@ -4312,195 +5188,248 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;1.0.5&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/1.0.5">1.0.5</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00221.0.5\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;1.0.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/1.0.4">1.0.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00221.0.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;1.0.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/1.0.5">1.0.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00221.0.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;1.0.3&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/1.0.3">1.0.3</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00221.0.3\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;1.0.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/1.0.4">1.0.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00221.0.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;1.0.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/1.0.2">1.0.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00221.0.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;1.0.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/1.0.3">1.0.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00221.0.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;1.0.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/1.0.0">1.0.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00221.0.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;1.0.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/1.0.2">1.0.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00221.0.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.5.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.5.4">0.5.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.5.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;1.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/1.0.0">1.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.5.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.5.2">0.5.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.5.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.5.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.5.4">0.5.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.5.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.5.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.5.1">0.5.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.5.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.5.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.5.2">0.5.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.5.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.5.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.5.0">0.5.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.5.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.5.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.5.1">0.5.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.5.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.4.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.4.2">0.4.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.4.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.5.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.5.0">0.5.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.5.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.4.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.4.1">0.4.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.4.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.4.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.4.2">0.4.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.4.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.4.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.4.0">0.4.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.4.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.4.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.4.1">0.4.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.4.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.3.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.3.2">0.3.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.3.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.4.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.4.0">0.4.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.4.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.3.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.3.1">0.3.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.3.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.3.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.3.2">0.3.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.3.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.3.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.3.0">0.3.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.3.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.3.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.3.1">0.3.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.3.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.2.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.2.1">0.2.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.2.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.3.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.3.0">0.3.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.3.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.2.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.2.0">0.2.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.2.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.2.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.2.1">0.2.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.2.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.1.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.1.2">0.1.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.1.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.2.0">0.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.1.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.1.1">0.1.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.1.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.1.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.1.2">0.1.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.1.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.1.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.1.0">0.1.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.1.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.1.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.1.1">0.1.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.1.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.0.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.0.1">0.0.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.0.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
-                        </p>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.1.0">0.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.0.1">0.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -4538,8 +5467,9 @@
 							rules_vivado
 							<a href="https://github.com/filmil/bazel_rules_vivado"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.5.0&#34;)">
@@ -4551,114 +5481,149 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.4.5&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.4.5">3.4.5</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.4.5\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.4.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.4.4">3.4.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.4.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.4.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.4.5">3.4.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.4.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.4.3&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.4.3">3.4.3</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.4.3\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.4.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.4.4">3.4.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.4.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.4.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.4.2">3.4.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.4.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.4.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.4.3">3.4.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.4.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.4.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.4.1">3.4.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.4.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.4.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.4.2">3.4.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.4.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.4.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.4.0">3.4.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.4.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.4.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.4.1">3.4.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.4.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.3.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.3.1">3.3.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.3.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.4.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.4.0">3.4.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.4.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.3.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.3.0">3.3.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.3.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.3.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.3.1">3.3.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.3.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.2.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.2.0">3.2.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.2.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.3.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.3.0">3.3.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.3.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.1.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.1.0">3.1.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.1.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.2.0">3.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.0.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.0.2">3.0.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.0.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.1.0">3.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.0.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.0.1">3.0.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.0.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
-                        </p>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.0.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.0.2">3.0.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.0.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.0.1">3.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -4746,8 +5711,9 @@
 							rules_vunit
 							<a href="https://github.com/filmil/bazel_rules_vunit"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vunit&#34;, version = &#34;1.2.2&#34;)">
@@ -4759,60 +5725,83 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vunit&#34;, version = &#34;1.2.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vunit/1.2.1">1.2.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vunit\u0022, version = \u00221.2.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vunit&#34;, version = &#34;1.2.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vunit/1.2.0">1.2.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vunit\u0022, version = \u00221.2.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vunit&#34;, version = &#34;1.2.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vunit/1.2.1">1.2.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vunit\u0022, version = \u00221.2.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vunit&#34;, version = &#34;1.1.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vunit/1.1.0">1.1.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vunit\u0022, version = \u00221.1.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vunit&#34;, version = &#34;1.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vunit/1.2.0">1.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vunit\u0022, version = \u00221.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vunit&#34;, version = &#34;1.0.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vunit/1.0.1">1.0.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vunit\u0022, version = \u00221.0.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vunit&#34;, version = &#34;1.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vunit/1.1.0">1.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vunit\u0022, version = \u00221.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vunit&#34;, version = &#34;1.0.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vunit/1.0.0">1.0.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vunit\u0022, version = \u00221.0.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vunit&#34;, version = &#34;1.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vunit/1.0.1">1.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vunit\u0022, version = \u00221.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vunit&#34;, version = &#34;0.0.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vunit/0.0.2">0.0.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vunit\u0022, version = \u00220.0.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
-                        </p>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vunit&#34;, version = &#34;1.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vunit/1.0.0">1.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vunit\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vunit&#34;, version = &#34;0.0.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vunit/0.0.2">0.0.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vunit\u0022, version = \u00220.0.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -4860,8 +5849,9 @@
 							upspin
 							<a href="https://github.com/filmil/upspin"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;43.0.2&#34;)">
@@ -4873,69 +5863,94 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;43.0.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/43.0.1">43.0.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002243.0.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;43.0.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/43.0.0">43.0.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002243.0.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;43.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/43.0.1">43.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002243.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;42.1.9&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/42.1.9">42.1.9</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002242.1.9\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;43.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/43.0.0">43.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002243.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;42.1.8&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/42.1.8">42.1.8</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002242.1.8\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;42.1.9&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/42.1.9">42.1.9</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002242.1.9\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;42.1.6&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/42.1.6">42.1.6</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002242.1.6\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;42.1.8&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/42.1.8">42.1.8</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002242.1.8\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;42.1.5&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/42.1.5">42.1.5</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002242.1.5\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;42.1.6&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/42.1.6">42.1.6</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002242.1.6\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;42.1.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/42.1.4">42.1.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002242.1.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
-                        </p>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;42.1.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/42.1.5">42.1.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002242.1.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;42.1.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/42.1.4">42.1.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002242.1.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -4998,8 +6013,9 @@
 							upspin_drive
 							<a href="https://github.com/filmil/upspin-gdrive"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin_drive&#34;, version = &#34;42.1.1&#34;)">
@@ -5011,15 +6027,28 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin_drive&#34;, version = &#34;0.1.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin_drive/0.1.2">0.1.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin_drive\u0022, version = \u00220.1.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
-                        </p>
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin_drive&#34;, version = &#34;0.1.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin_drive/0.1.2">0.1.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin_drive\u0022, version = \u00220.1.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -5082,8 +6111,9 @@
 							vhdl_ls_gen
 							<a href="https://github.com/filmil/bazel_vhdl_ls_gen"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.3.0&#34;)">
@@ -5095,105 +6125,138 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.2.6&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.2.6">0.2.6</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.2.6\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.2.5&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.2.5">0.2.5</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.2.5\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.2.6&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.2.6">0.2.6</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.2.6\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.2.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.2.4">0.2.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.2.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.2.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.2.5">0.2.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.2.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.2.3&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.2.3">0.2.3</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.2.3\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.2.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.2.4">0.2.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.2.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.2.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.2.1">0.2.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.2.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.2.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.2.3">0.2.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.2.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.2.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.2.0">0.2.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.2.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.2.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.2.1">0.2.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.2.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.1.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.1.2">0.1.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.1.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.2.0">0.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.1.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.1.1">0.1.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.1.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.1.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.1.2">0.1.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.1.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.1.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.1.0">0.1.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.1.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.1.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.1.1">0.1.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.1.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.0.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.0.2">0.0.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.0.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.1.0">0.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.0.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.0.1">0.0.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.0.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
-                        </p>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.0.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.0.2">0.0.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.0.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.0.1">0.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -5236,8 +6299,9 @@
 							xrootfs
 							<a href="https://github.com/filmil/xrootfs"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.9&#34;)">
@@ -5249,105 +6313,138 @@
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.3&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.3">0.2.3</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.3\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.21&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.21">0.2.21</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.21\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.3">0.2.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.2&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.2">0.2.2</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.2\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.21&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.21">0.2.21</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.21\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.17&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.17">0.2.17</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.17\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.2">0.2.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.11&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.11">0.2.11</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.11\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.17&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.17">0.2.17</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.17\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.1&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.1">0.2.1</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.1\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.11&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.11">0.2.11</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.11\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.0&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.0">0.2.0</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.0\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.1">0.2.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.1.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.1.4">0.1.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.1.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.0">0.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.1.3&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.1.3">0.1.3</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.1.3\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.1.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.1.4">0.1.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.1.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.0.4&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.0.4">0.0.4</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.0.4\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.1.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.1.3">0.1.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.1.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
 
 
 
-                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.0.3&#34;)">
-                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.0.3">0.0.3</a>
-                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.0.3\u0022)'); return false;">
-                                            <i class="bi bi-clipboard"></i>
-                                        </a>
-                                    </span>
 
 
-                        </p>
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.0.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.0.4">0.0.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.0.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+
+
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.0.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.0.3">0.0.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.0.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+
+
+
+                                        </div>
+                                    </details>
+
+
+                        </div>
 
 
 
@@ -5405,8 +6502,9 @@
 							zlib_foreign
 							<a href="https://github.com/filmil/bazel_zlib_foreign"><i class="bi bi-link-45deg"></i></a>
 						</h5>
-                        <p class="card-text">
+                        <div class="card-text mb-2">
                             <strong>Versions:</strong>
+
 
 
                                     <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;zlib_foreign&#34;, version = &#34;0.0.1&#34;)">
@@ -5417,7 +6515,9 @@
                                     </span>
 
 
-                        </p>
+
+
+                        </div>
 
 
 


### PR DESCRIPTION
Modified the bazel-registry page generator to display only the latest version of each module by default, moving older versions into a collapsible details UI block. Fixes #546.

---
*PR created automatically by Jules for task [5641310098406806570](https://jules.google.com/task/5641310098406806570) started by @filmil*