### PR TITLE
Modify the bazel-registry page generator to put links behind a zippy

### DIFF
--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -442,11 +442,16 @@ const htmlTemplate = `
                                 </details>
                             {{end}}
                         {{end}}
-                        <p class="card-text"><a href="{{$module.Metadata.Homepage}}">{{$module.Metadata.Homepage}}</a></p>
-                        <p class="card-text">
-                            {{$repo := index $module.Metadata.Repo 0}}
-							<a href="{{repoURL $repo}}">{{$repo}}</a>
-                        </p>
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="{{$module.Metadata.Homepage}}">{{$module.Metadata.Homepage}}</a></li>
+                            <li>
+                                {{$repo := index $module.Metadata.Repo 0}}
+                                <a href="{{repoURL $repo}}">{{$repo}}</a>
+                            </li>
+                        </ul>
+                        </details>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
This commit modifies the HTML template in `cmd/generate/main.go` to group the module's homepage and repository links into an unordered list inside a `<details>` element (zippy) with a "Links:" summary. This visually matches the style of the dependencies section and cleans up the UI.

Fixes #545

---
*PR created automatically by Jules for task [8208894983783376200](https://jules.google.com/task/8208894983783376200) started by @filmil*