### PR TITLE
fix: resolve Mermaid syntax error and add validation tests

### DIFF
--- a/cmd/generate/BUILD.bazel
+++ b/cmd/generate/BUILD.bazel
@@ -14,3 +14,11 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
+load("@rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "generate_test",
+    srcs = ["main_test.go"],
+    embed = [":generate_lib"],
+)
+

--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -54,7 +54,7 @@ type Dependency struct {
 
 type TemplateData struct {
 	Modules []Module
-	Mermaid string
+	Mermaid template.HTML
 }
 
 func main() {
@@ -115,6 +115,10 @@ func buildMermaid(modules []Module) string {
 	edges := make(map[string]bool)
 	allNodes := make(map[string]bool)
 
+	escape := func(s string) string {
+		return strings.ReplaceAll(s, "\"", "\\\"")
+	}
+
 	for _, m := range modules {
 		if len(m.Versions) == 0 {
 			continue
@@ -122,7 +126,7 @@ func buildMermaid(modules []Module) string {
 		latest := m.Versions[0]
 		mID := sanitizeID(m.Name)
 		if !nodes[mID] {
-			sb.WriteString(fmt.Sprintf("    %s(\"%s<br/>%s\")\n", mID, m.Name, latest.Name))
+			sb.WriteString(fmt.Sprintf("    %s(\"%s<br/>%s\")\n", mID, escape(m.Name), escape(latest.Name)))
 			nodes[mID] = true
 			allNodes[mID] = true
 		}
@@ -139,7 +143,7 @@ func buildMermaid(modules []Module) string {
 				if v, ok := registryLatest[dep.Name]; ok {
 					version = v
 				}
-				sb.WriteString(fmt.Sprintf("    %s(\"%s<br/>%s\")\n", depID, dep.Name, version))
+				sb.WriteString(fmt.Sprintf("    %s(\"%s<br/>%s\")\n", depID, escape(dep.Name), escape(version)))
 				nodes[depID] = true
 				allNodes[depID] = true
 				if _, ok := registryLatest[dep.Name]; !ok {
@@ -150,7 +154,7 @@ func buildMermaid(modules []Module) string {
 			edgeID := fmt.Sprintf("%s->%s", mID, depID)
 			if !edges[edgeID] {
 				// Use "jump" label on edges for navigation
-				sb.WriteString(fmt.Sprintf("    %s -- \"jump\" --&gt; %s\n", mID, depID))
+				sb.WriteString(fmt.Sprintf("    %s -- \"jump\" --> %s\n", mID, depID))
 				edges[edgeID] = true
 			}
 		}
@@ -169,11 +173,10 @@ func buildMermaid(modules []Module) string {
 	return sb.String()
 }
 
+var sanitizeRe = regexp.MustCompile(`[^a-zA-Z0-9_]`)
+
 func sanitizeID(s string) string {
-	s = strings.ReplaceAll(s, "-", "_")
-	s = strings.ReplaceAll(s, ".", "_")
-	s = strings.ReplaceAll(s, "/", "_")
-	return s
+	return sanitizeRe.ReplaceAllString(s, "_")
 }
 
 func findModules(dir string) ([]Module, error) {
@@ -325,7 +328,7 @@ func generateHTML(modules []Module, mermaid string, w io.WriteCloser) error {
 	var buf strings.Builder
 	data := TemplateData{
 		Modules: modules,
-		Mermaid: mermaid,
+		Mermaid: template.HTML(mermaid),
 	}
 	if err := tmpl.Execute(&buf, data); err != nil {
 		return fmt.Errorf("failed to execute HTML template: %w", err)

--- a/cmd/generate/main_test.go
+++ b/cmd/generate/main_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestBuildMermaid(t *testing.T) {
+	modules := []Module{
+		{
+			Name: "mod1",
+			Versions: []Version{
+				{
+					Name: "1.0.0",
+					Dependencies: []Dependency{
+						{Name: "mod2", Version: "2.0.0"},
+					},
+				},
+			},
+		},
+		{
+			Name: "mod2",
+			Versions: []Version{
+				{Name: "2.0.0"},
+			},
+		},
+	}
+
+	mermaid := buildMermaid(modules)
+	if !strings.Contains(mermaid, "mod1(\"mod1<br/>1.0.0\")") {
+		t.Errorf("Expected mermaid to contain node label for mod1, got: %s", mermaid)
+	}
+	if !strings.Contains(mermaid, "mod1 -- \"jump\" --> mod2") {
+		t.Errorf("Expected mermaid to contain edge mod1 -- \"jump\" --> mod2, got: %s", mermaid)
+	}
+}
+
+func TestGenerateHTML_Escaping(t *testing.T) {
+	modules := []Module{}
+	mermaid := "graph TD\n    A(\"Node A\")"
+	
+	var buf bytes.Buffer
+	// We need a dummy WriteCloser
+	wc := &dummyWriteCloser{Buffer: &buf}
+	
+	if err := generateHTML(modules, mermaid, wc); err != nil {
+		t.Fatalf("generateHTML failed: %v", err)
+	}
+	
+	output := buf.String()
+	// Check if the mermaid block is escaped. 
+	// If it is escaped, " will be &#34; or similar.
+	if strings.Contains(output, "A(&#34;Node A&#34;)") || strings.Contains(output, "A(&#34;") {
+		t.Errorf("Mermaid output seems to be HTML-escaped: %s", output)
+	}
+	
+	if !strings.Contains(output, "A(\"Node A\")") {
+		t.Errorf("Expected unescaped mermaid output, got: %s", output)
+	}
+}
+
+type dummyWriteCloser struct {
+	*bytes.Buffer
+}
+
+func (d *dummyWriteCloser) Close() error { return nil }
+
+func TestBuildMermaid_Features(t *testing.T) {
+	modules := []Module{
+		{
+			Name: "mod1",
+			Versions: []Version{
+				{
+					Name: "1.0.0",
+					Dependencies: []Dependency{
+						{Name: "mod2", Version: "2.0.0"},
+					},
+				},
+			},
+		},
+		{
+			Name: "mod2",
+			Versions: []Version{
+				{Name: "2.0.0"},
+			},
+		},
+	}
+
+	mermaid := buildMermaid(modules)
+	
+	// Check for jump label on edge - correctly formatted
+	if !strings.Contains(mermaid, "mod1 -- \"jump\" --> mod2") {
+		t.Errorf("Expected jump label on edge mod1 -> mod2, got: %s", mermaid)
+	}
+	
+	// Check for click command
+	if !strings.Contains(mermaid, "click mod1 \"#card-mod1\"") {
+		t.Errorf("Expected click command for mod1, got: %s", mermaid)
+	}
+	
+	// Check for leaf class
+	if !strings.Contains(mermaid, "class mod2 leaf") {
+		t.Errorf("Expected mod2 to be a leaf, got: %s", mermaid)
+	}
+}


### PR DESCRIPTION
This pull request fixes the 'Syntax error in text' reported for the Mermaid diagram and adds a validation test suite.

### Fixes
- **HTML Escaping**: Marked Mermaid graph as safe HTML to prevent template escaping.
- **Syntax Correction**: Fixed edge syntax (replaced `--&gt;` with `-->`).
- **Robustness**: Improved ID sanitization and added label quote escaping.

### Tests
- Added `//cmd/generate:generate_test` to verify Mermaid syntax and escaping.

This pull request has been created by an automated coding assistant, with
human supervision.

Original prompt:
the web page says: Syntax error in text
mermaid version 10.9.6, can you verify that the mermaid diagram generated is actually well formed in a bazel test