### PR TITLE
fix: maximize DAG viewport height

### DIFF
--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -494,7 +494,6 @@ const htmlTemplate = `
         max-width: 100%;
       }
       .mermaid svg {
-        height: auto !important;
         max-width: 100% !important;
       }
       .mermaid .inverted rect {
@@ -527,7 +526,8 @@ const htmlTemplate = `
         border-radius: 4px;
         background-color: var(--bs-body-bg);
         position: relative;
-        height: 600px;
+        height: 80vh; /* Use 80% of viewport height */
+        min-height: 600px;
         width: 100%;
         overflow: hidden;
       }


### PR DESCRIPTION
This pull request fixes an issue where the dependency DAG was constrained to only a portion of its container's height.

### Fixes
- **CSS Correction**: Removed `height: auto !important` from the Mermaid SVG styling. This property was overriding the height settings applied by the `svg-pan-zoom` library, causing the diagram to shrink based on its natural aspect ratio.
- **Improved Layout**: Increased the container height to **80vh** (80% of the viewport height) with a minimum of 600px. This provides a much larger and more immersive area for exploring the module dependencies.

This pull request has been created by an automated coding assistant, with
human supervision.

Original prompt:
in a new pr, figure out why the actual view in the mermaid viewer only takes up half the height of the viewport, and fix it