### PR TITLE
feat: fix DAG label newlines

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,4 +12,3 @@ gazelle(name = "gazelle")
 buildifier(
     name = "buildifier",
 )
-

--- a/cmd/generate/BUILD.bazel
+++ b/cmd/generate/BUILD.bazel
@@ -1,11 +1,10 @@
-load("@rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 
 go_library(
     name = "generate_lib",
     srcs = ["main.go"],
     importpath = "github.com/filmil/bazel-registry/cmd/generate",
     visibility = ["//visibility:private"],
-    deps = ["@rules_go//go/runfiles"],
 )
 
 go_binary(
@@ -14,11 +13,8 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
-load("@rules_go//go:def.bzl", "go_test")
-
 go_test(
     name = "generate_test",
     srcs = ["main_test.go"],
     embed = [":generate_lib"],
 )
-

--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -154,8 +154,8 @@ func buildMermaid(modules []Module) string {
 		for _, name := range externalNames {
 			labelLabels = append(labelLabels, fmt.Sprintf("%s (%s)", name, externalModulesSet[name]))
 		}
-		label := strings.Join(labelLabels, "<br/>")
-		sb.WriteString(fmt.Sprintf("    %s(\"%s\")\n", externalNodeID, escape(label)))
+		label := strings.Join(labelLabels, "\n")
+		sb.WriteString(fmt.Sprintf("    %s[\"%s\"]\n", externalNodeID, escape(label)))
 		sb.WriteString(fmt.Sprintf("    class %s inverted\n", externalNodeID))
 		allNodes[externalNodeID] = true
 	}
@@ -167,7 +167,7 @@ func buildMermaid(modules []Module) string {
 		latest := m.Versions[0]
 		mID := sanitizeID(m.Name)
 		if !nodes[mID] {
-			sb.WriteString(fmt.Sprintf("    %s(\"%s<br/>%s\")\n", mID, escape(m.Name), escape(latest.Name)))
+			sb.WriteString(fmt.Sprintf("    %s[\"%s\n%s\"]\n", mID, escape(m.Name), escape(latest.Name)))
 			nodes[mID] = true
 			allNodes[mID] = true
 		}
@@ -180,7 +180,7 @@ func buildMermaid(modules []Module) string {
 				hasInternalDeps = true
 				if !nodes[depID] {
 					version := registryLatest[dep.Name]
-					sb.WriteString(fmt.Sprintf("    %s(\"%s<br/>%s\")\n", depID, escape(dep.Name), escape(version)))
+					sb.WriteString(fmt.Sprintf("    %s[\"%s\n%s\"]\n", depID, escape(dep.Name), escape(version)))
 					nodes[depID] = true
 					allNodes[depID] = true
 				}

--- a/cmd/generate/main_test.go
+++ b/cmd/generate/main_test.go
@@ -135,3 +135,25 @@ func TestBuildMermaid_Robustness(t *testing.T) {
 		t.Errorf("Expected escaped label %s, got: %s", expectedLabel, mermaid)
 	}
 }
+
+func TestBuildMermaid_NewlineRendering(t *testing.T) {
+	modules := []Module{
+		{
+			Name: "my_module",
+			Versions: []Version{
+				{
+					Name: "1.2.3",
+				},
+			},
+		},
+	}
+
+	mermaid := buildMermaid(modules)
+	
+	// We want to ensure that there is a literal newline character between 
+	// the module name and the version within the node label brackets.
+	expected := "my_module[\"my_module\n1.2.3\"]"
+	if !strings.Contains(mermaid, expected) {
+		t.Errorf("Expected mermaid to contain label with literal newline %q, but it was not found. Full mermaid:\n%s", expected, mermaid)
+	}
+}

--- a/cmd/generate/main_test.go
+++ b/cmd/generate/main_test.go
@@ -28,7 +28,7 @@ func TestBuildMermaid(t *testing.T) {
 	}
 
 	mermaid := buildMermaid(modules)
-	if !strings.Contains(mermaid, "mod1(\"mod1<br/>1.0.0\")") {
+	if !strings.Contains(mermaid, "mod1[\"mod1\n1.0.0\"]") {
 		t.Errorf("Expected mermaid to contain node label for mod1, got: %s", mermaid)
 	}
 	if !strings.Contains(mermaid, "mod1 -- \"jump\" --> mod2") {
@@ -38,7 +38,7 @@ func TestBuildMermaid(t *testing.T) {
 
 func TestGenerateHTML_Escaping(t *testing.T) {
 	modules := []Module{}
-	mermaid := "graph TD\n    A(\"Node A\")"
+	mermaid := "graph TD\n    A[\"Node A\"]"
 	
 	var buf bytes.Buffer
 	// We need a dummy WriteCloser
@@ -50,12 +50,11 @@ func TestGenerateHTML_Escaping(t *testing.T) {
 	
 	output := buf.String()
 	// Check if the mermaid block is escaped. 
-	// If it is escaped, " will be &#34; or similar.
-	if strings.Contains(output, "A(&#34;Node A&#34;)") || strings.Contains(output, "A(&#34;") {
+	if strings.Contains(output, "A[&#34;Node A&#34;]") || strings.Contains(output, "A[&#34;") {
 		t.Errorf("Mermaid output seems to be HTML-escaped: %s", output)
 	}
 	
-	if !strings.Contains(output, "A(\"Node A\")") {
+	if !strings.Contains(output, "A[\"Node A\"]") {
 		t.Errorf("Expected unescaped mermaid output, got: %s", output)
 	}
 }
@@ -102,5 +101,37 @@ func TestBuildMermaid_Features(t *testing.T) {
 	// Check for leaf class
 	if !strings.Contains(mermaid, "class mod2 leaf") {
 		t.Errorf("Expected mod2 to be a leaf, got: %s", mermaid)
+	}
+}
+
+func TestBuildMermaid_Robustness(t *testing.T) {
+	modules := []Module{
+		{
+			Name: "my-module:with:colon",
+			Versions: []Version{
+				{
+					Name: "1.0.0\"quote",
+					Dependencies: []Dependency{
+						{Name: "other/mod", Version: "2.0.0"},
+					},
+				},
+			},
+		},
+	}
+
+	mermaid := buildMermaid(modules)
+	
+	// The ID should be sanitized (colons and slashes to underscores)
+	if strings.Contains(mermaid, "my-module:with:colon[") {
+		t.Errorf("Found unsanitized ID in mermaid: %s", mermaid)
+	}
+	if !strings.Contains(mermaid, "my_module_with_colon[") {
+		t.Errorf("Expected sanitized ID my_module_with_colon, got: %s", mermaid)
+	}
+
+	// The label should contain the original name and version, but with escaped quotes
+	expectedLabel := "[\"my-module:with:colon\n1.0.0\\\"quote\"]"
+	if !strings.Contains(mermaid, expectedLabel) {
+		t.Errorf("Expected escaped label %s, got: %s", expectedLabel, mermaid)
 	}
 }

--- a/index_test.html
+++ b/index_test.html
@@ -1,0 +1,7424 @@
+
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Bazel Registry</title>
+    <link
+		href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css"
+		rel="stylesheet"
+	>
+    <link
+		href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.3/font/bootstrap-icons.css"
+		rel="stylesheet"
+	>
+	<link rel="icon" href="hdlfactory.png" type="image/png">
+	
+	<script async src="https://www.googletagmanager.com/gtag/js?id=G-BKGTF9GD1K"></script>
+	<script>
+	  window.dataLayer = window.dataLayer || [];
+	  function gtag(){dataLayer.push(arguments);}
+	  gtag('js', new Date());
+
+	  gtag('config', 'G-BKGTF9GD1K');
+	</script>
+	<script>
+      function getPreferredTheme() {
+        const savedTheme = localStorage.getItem('theme');
+        if (savedTheme) {
+          return savedTheme;
+        }
+        return 'system';
+      }
+
+      function resolveTheme(theme) {
+        if (theme === 'system') {
+          const currentHour = new Date().getHours();
+          return (currentHour >= 19 || currentHour < 7) ? 'dark' : 'light';
+        }
+        return theme;
+      }
+
+      function updateThemeIcon(theme) {
+        const toggleBtn = document.getElementById('themeToggle');
+        if (toggleBtn) {
+          if (theme === 'light') {
+            toggleBtn.innerHTML = '<i class="bi bi-sun"></i>';
+          } else if (theme === 'dark') {
+            toggleBtn.innerHTML = '<i class="bi bi-moon-stars"></i>';
+          } else {
+            toggleBtn.innerHTML = '<i class="bi bi-circle-half"></i>';
+          }
+        }
+      }
+
+      function setTheme(theme) {
+        document.documentElement.setAttribute('data-bs-theme', resolveTheme(theme));
+        localStorage.setItem('theme', theme);
+        updateThemeIcon(theme);
+      }
+
+      setTheme(getPreferredTheme());
+
+      document.addEventListener('DOMContentLoaded', () => {
+        updateThemeIcon(getPreferredTheme());
+      });
+
+      function toggleTheme() {
+        const currentTheme = getPreferredTheme();
+        let newTheme;
+        if (currentTheme === 'system') {
+          newTheme = 'light';
+        } else if (currentTheme === 'light') {
+          newTheme = 'dark';
+        } else {
+          newTheme = 'system';
+        }
+        setTheme(newTheme);
+      }
+	</script>
+	<style>
+      [data-bs-theme="dark"] {
+        --bs-body-color: #e9ecef;
+        --bs-secondary-color: #adb5bd;
+        --bs-tertiary-color: #dee2e6;
+        --bs-link-color: #6ea8fe;
+        --bs-link-hover-color: #9ec5fe;
+      }
+      [data-bs-theme="dark"] .card-title {
+        color: #6ea8fe;
+      }
+      [data-bs-theme="dark"] .text-secondary {
+        color: #ced4da !important;
+      }
+      [data-bs-theme="dark"] .text-muted {
+        color: #adb5bd !important;
+      }
+      [data-bs-theme="dark"] code:not(pre code) {
+        background-color: var(--bs-tertiary-bg);
+        color: #e6edf3;
+      }
+      [data-bs-theme="dark"] blockquote {
+        background-color: var(--bs-tertiary-bg);
+        border-left-color: var(--bs-border-color);
+        color: var(--bs-secondary-color);
+      }
+       
+      .mermaid {
+        overflow-x: auto;
+        max-width: 100%;
+      }
+      .mermaid svg {
+        max-width: 100% !important;
+      }
+      .mermaid .inverted rect {
+        fill: #333 !important;
+        stroke: #000 !important;
+      }
+      .mermaid .inverted .label, .mermaid .inverted span {
+        color: #fff !important;
+      }
+
+       
+      .mermaid .leaf rect {
+        fill: #28a745 !important;
+        stroke: #1e7e34 !important;
+      }
+      .mermaid .leaf .label, .mermaid .leaf span {
+        color: #fff !important;
+      }
+
+      [data-bs-theme="dark"] .mermaid .inverted rect {
+        fill: #eee !important;
+        stroke: #fff !important;
+      }
+      [data-bs-theme="dark"] .mermaid .inverted .label, [data-bs-theme="dark"] .mermaid .inverted span {
+        color: #111 !important;
+      }
+	       
+      #mermaid-container {
+        border: 1px solid var(--bs-border-color);
+        border-radius: 4px;
+        background-color: var(--bs-body-bg);
+        position: relative;
+        height: 85vh;  
+        min-height: 600px;
+        width: 100%;
+        overflow: hidden;
+      }
+      #dag-mermaid {
+        width: 100%;
+        height: 100%;
+      }
+      #dag-mermaid {
+        width: 100%;
+        height: 100%;
+      }
+      #mermaid-zoom-controls {
+        position: absolute;
+        top: 10px;
+        left: 10px;
+        z-index: 100;
+        display: flex;
+        flex-direction: column;
+        gap: 5px;
+      }
+	</style>
+    <script src="https://cdn.jsdelivr.net/npm/svg-pan-zoom@3.6.1/dist/svg-pan-zoom.min.js"></script>
+</head>
+<body>
+    <div class="container">
+		<div class="d-flex justify-content-between align-items-center mt-5">
+			<h1 class="mb-0"><a href="https://www.hdlfactory.com">My</a> <a
+			href="https://bazel.build">Bazel</a> Registry</h1>
+			<button class="btn btn-outline-secondary" onclick="toggleTheme()" id="themeToggle" title="Toggle theme">
+				<i class="bi bi-circle-half"></i>
+			</button>
+		</div>
+
+		<p>These modules are published in <a
+		href="https://github.com/filmil/bazel-registry">my private bazel
+		registry</a> See the <a
+		href="https://github.com/filmil/bazel-registry#usage">usage details</a>
+		for how to configure bazel use this additional registry. </p>
+
+		<p> The bazel central registry is still available at <a
+		href="https://bcr.bazel.build"> https://bcr.bazel.build</a>. </p>
+
+        <input class="form-control mb-4" id="searchInput" type="text" placeholder="Search for modules...">
+        <div class="row" id="module-cards">
+            
+            <div class="col-md-4 mb-4 module-card" id="card-bazel_go_basic">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							bazel-go-basic
+							<a href="https://github.com/filmil/bazel-go-basic"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel-go-basic&#34;, version = &#34;0.2.21&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel-go-basic/0.2.21">0.2.21</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel-go-basic\u0022, version = \u00220.2.21\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel-go-basic&#34;, version = &#34;0.2.20&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel-go-basic/0.2.20">0.2.20</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel-go-basic\u0022, version = \u00220.2.20\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel-go-basic&#34;, version = &#34;0.2.19&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel-go-basic/0.2.19">0.2.19</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel-go-basic\u0022, version = \u00220.2.19\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel-go-basic&#34;, version = &#34;0.1.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel-go-basic/0.1.4">0.1.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel-go-basic\u0022, version = \u00220.1.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>buildifier_prebuilt</code> (8.2.0.2)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>gazelle</code> (0.45.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_go</code> (0.57.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_pkg</code> (1.0.1)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://github.com/filmil/bazel-go-basic">https://github.com/filmil/bazel-go-basic</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/bazel-go-basic">github:filmil/bazel-go-basic</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-bazel_bats">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							bazel_bats
+							<a href="https://www.hdlfactory.com"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_bats&#34;, version = &#34;0.38.23&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_bats/0.38.23">0.38.23</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_bats\u0022, version = \u00220.38.23\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_bats&#34;, version = &#34;0.37.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_bats/0.37.1">0.37.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_bats\u0022, version = \u00220.37.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_bats&#34;, version = &#34;0.37.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_bats/0.37.0">0.37.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_bats\u0022, version = \u00220.37.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_bats&#34;, version = &#34;0.36.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_bats/0.36.4">0.36.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_bats\u0022, version = \u00220.36.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_bats&#34;, version = &#34;0.36.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_bats/0.36.2">0.36.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_bats\u0022, version = \u00220.36.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_bats&#34;, version = &#34;0.36.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_bats/0.36.0">0.36.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_bats\u0022, version = \u00220.36.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>bazel_skylib</code> (1.7.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>bazel_skylib_gazelle_plugin</code> (1.7.1)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+                                
+                                    <li>
+                                        <code>gazelle</code> (0.42.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://www.hdlfactory.com">https://www.hdlfactory.com</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/bazel-bats">github:filmil/bazel-bats</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-bazel_debian_rootfs">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							bazel_debian_rootfs
+							<a href="https://github.com/filmil/bazel_debian_rootfs"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_debian_rootfs&#34;, version = &#34;0.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_debian_rootfs/0.0.1">0.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_debian_rootfs\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>bazel_rules_bid</code> (0.3.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>bazel_skylib</code> (1.7.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>gotopt2</code> (2.2.2)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_distroless</code> (0.5.3)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_multitool</code> (1.9.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_oci</code> (2.2.6)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://github.com/filmil/bazel_debian_rootfs">https://github.com/filmil/bazel_debian_rootfs</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/bazel_debian_rootfs">github:filmil/bazel_debian_rootfs</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-bazel_ebook">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							bazel_ebook
+							<a href="https://hdlfactory.com/post/2025/02/04/typeset-your-own-ebooks-easily-with-bazel-ebook"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;2.0.15&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/2.0.15">2.0.15</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00222.0.15\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;1.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/1.0.0">1.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.2.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.2.5">0.2.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.2.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.2.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.2.4">0.2.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.2.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.2.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.2.3">0.2.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.2.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.2.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.2.2">0.2.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.2.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.2.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.2.1">0.2.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.2.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.1.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.1.1">0.1.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.1.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.0.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.0.5">0.0.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.0.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.0.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.0.4">0.0.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.0.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.0.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.0.3">0.0.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.0.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_ebook&#34;, version = &#34;0.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_ebook/0.0.1">0.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_ebook\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>bazel_bats</code> (0.38.9)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>bazel_rules_bid</code> (1.2.4)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>bazel_skylib</code> (1.9.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>buildifier_prebuilt</code> (8.2.1.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>gazelle</code> (0.47.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>platforms</code> (1.0.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_cc</code> (0.2.16)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_multitool</code> (1.11.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_pkg</code> (1.2.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_python</code> (1.8.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_python_gazelle_plugin</code> (1.8.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://hdlfactory.com/post/2025/02/04/typeset-your-own-ebooks-easily-with-bazel-ebook">https://hdlfactory.com/post/2025/02/04/typeset-your-own-ebooks-easily-with-bazel-ebook</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/bazel-ebook">github:filmil/bazel-ebook</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-bazel_rootfs">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							bazel_rootfs
+							<a href="https://hdlfactory.com/tags/bazel-modules"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rootfs&#34;, version = &#34;1.0.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rootfs/1.0.3">1.0.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rootfs\u0022, version = \u00221.0.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rootfs&#34;, version = &#34;1.0.26&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rootfs/1.0.26">1.0.26</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rootfs\u0022, version = \u00221.0.26\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rootfs&#34;, version = &#34;1.0.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rootfs/1.0.2">1.0.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rootfs\u0022, version = \u00221.0.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rootfs&#34;, version = &#34;1.0.18&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rootfs/1.0.18">1.0.18</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rootfs\u0022, version = \u00221.0.18\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rootfs&#34;, version = &#34;1.0.12&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rootfs/1.0.12">1.0.12</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rootfs\u0022, version = \u00221.0.12\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rootfs&#34;, version = &#34;1.0.10&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rootfs/1.0.10">1.0.10</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rootfs\u0022, version = \u00221.0.10\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rootfs&#34;, version = &#34;1.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rootfs/1.0.1">1.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rootfs\u0022, version = \u00221.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>bazel_rules_bid</code> (0.3.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>bazel_skylib</code> (1.7.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>gotopt2</code> (2.2.2)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_distroless</code> (0.5.3)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_multitool</code> (1.9.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_oci</code> (2.2.6)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_zstd</code> (1.0.0)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://hdlfactory.com/tags/bazel-modules">https://hdlfactory.com/tags/bazel-modules</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/bazel_debian_rootfs">github:filmil/bazel_debian_rootfs</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-bazel_rules_bid">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							bazel_rules_bid
+							<a href="https://hdlfactory.com/post/2025/02/11/bazel-rules-for-build-in-docker-or-bid/"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.4.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.4.0">1.4.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.4.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.3.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.3.0">1.3.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.3.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.2.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.2.4">1.2.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.2.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.2.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.2.3">1.2.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.2.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.2.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.2.2">1.2.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.2.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.2.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.2.1">1.2.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.2.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.2.0">1.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.1.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.1.3">1.1.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.1.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.1.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.1.2">1.1.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.1.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.1.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.1.1">1.1.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.1.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.1.0">1.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.0.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.0.4">1.0.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.0.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.0.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.0.3">1.0.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.0.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.0.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.0.2">1.0.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.0.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.0.10&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.0.10">1.0.10</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.0.10\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;1.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/1.0.0">1.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;0.3.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/0.3.0">0.3.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00220.3.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;0.2.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/0.2.5">0.2.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00220.2.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;0.2.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/0.2.4">0.2.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00220.2.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;0.2.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/0.2.3">0.2.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00220.2.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;0.2.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/0.2.2">0.2.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00220.2.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;0.2.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/0.2.1">0.2.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00220.2.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bid&#34;, version = &#34;0.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bid/0.2.0">0.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bid\u0022, version = \u00220.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>bazel_skylib</code> (1.7.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>bazel_skylib_gazelle_plugin</code> (1.7.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>buildifier_prebuilt</code> (7.3.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>fshlib</code> (0.2.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_multitool</code> (1.0.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://hdlfactory.com/post/2025/02/11/bazel-rules-for-build-in-docker-or-bid/">https://hdlfactory.com/post/2025/02/11/bazel-rules-for-build-in-docker-or-bid/</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/bazel-rules-bid">github:filmil/bazel-rules-bid</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-bazel_rules_bt">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							bazel_rules_bt
+							<a href="https://www.hdlfactory.com"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bt&#34;, version = &#34;0.0.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bt/0.0.3">0.0.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bt\u0022, version = \u00220.0.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_bt&#34;, version = &#34;0.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_bt/0.0.1">0.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_bt\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>rules_multitool</code> (1.8.0)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://www.hdlfactory.com">https://www.hdlfactory.com</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/bazel_rules_bt">github:filmil/bazel_rules_bt</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-bazel_rules_ghdl">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							bazel_rules_ghdl
+							<a href="https://github.com/filmil/bazel_rules_ghdl"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;1.0.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/1.0.0">1.0.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.7&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.7">0.1.7</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.7\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.6&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.6">0.1.6</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.6\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.5">0.1.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.4">0.1.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.3">0.1.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.24&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.24">0.1.24</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.24\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.21&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.21">0.1.21</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.21\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.19&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.19">0.1.19</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.19\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.17&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.17">0.1.17</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.17\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.15&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.15">0.1.15</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.15\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.13&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.13">0.1.13</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.13\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.12&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.12">0.1.12</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.12\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.10&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.10">0.1.10</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.10\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.1">0.1.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.1.0">0.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_ghdl&#34;, version = &#34;0.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_ghdl/0.0.1">0.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_ghdl\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>bazel_rules_bid</code> (1.4.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>bazel_skylib</code> (1.9.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>gotopt2</code> (2.3.3)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_distroless</code> (0.8.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_multitool</code> (1.11.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_oci</code> (2.3.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_shell</code> (0.8.0)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://github.com/filmil/bazel_rules_ghdl">https://github.com/filmil/bazel_rules_ghdl</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/bazel_go_basic">github:filmil/bazel_go_basic</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-bazel_rules_nvc">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							bazel_rules_nvc
+							<a href="https://github.com/filmil/bazel_rules_nvc"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.5.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.5.2">0.5.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.5.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.5.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.5.1">0.5.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.5.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.5.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.5.0">0.5.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.5.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.4.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.4.1">0.4.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.4.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.4.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.4.0">0.4.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.4.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.3.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.3.2">0.3.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.3.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.3.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.3.1">0.3.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.3.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.3.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.3.0">0.3.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.3.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.9&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.9">0.2.9</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.9\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.8&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.8">0.2.8</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.8\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.7&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.7">0.2.7</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.7\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.6&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.6">0.2.6</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.6\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.4">0.2.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.2">0.2.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.11&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.11">0.2.11</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.11\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.10&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.10">0.2.10</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.10\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.1">0.2.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.2.0">0.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.1.0">0.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.0.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.0.2">0.0.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.0.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_nvc&#34;, version = &#34;0.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_nvc/0.0.1">0.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_nvc\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>bazel_lib</code> (3.0.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>bazel_skylib</code> (1.8.2)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>bazel_skylib_gazelle_plugin</code> (1.8.2)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>elfutils</code> (0.4.4)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>fshlib</code> (0.1.5)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>gazelle</code> (0.47.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>gotopt2</code> (2.2.2)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>libffi</code> (3.4.7.bcr.3)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>platforms</code> (1.0.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_cc</code> (0.2.8)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_foreign_cc</code> (0.15.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>toolchains_llvm</code> (1.5.0)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+                                
+                                    <li>
+                                        <code>zlib</code> (1.3.1.bcr.7)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>zstd</code> (1.5.7)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://github.com/filmil/bazel_rules_nvc">https://github.com/filmil/bazel_rules_nvc</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/bazel_rules_nvc">github:filmil/bazel_rules_nvc</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-bazel_rules_osvvm">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							bazel_rules_osvvm
+							<a href="https://github.com/filmil/bazel_nvc_osvvm"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_osvvm&#34;, version = &#34;0.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_osvvm/0.0.1">0.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_osvvm\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>bazel_rules_nvc</code> (0.5.2)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>toolchains_llvm</code> (1.5.0)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://github.com/filmil/bazel_nvc_osvvm">https://github.com/filmil/bazel_nvc_osvvm</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/bazel_nvc_osvvm">github:filmil/bazel_nvc_osvvm</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-bazel_rules_raylib">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							bazel_rules_raylib
+							<a href="https://github.com/filmil/bazel_rules_raylib"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_raylib&#34;, version = &#34;0.0.7&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_raylib/0.0.7">0.0.7</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_raylib\u0022, version = \u00220.0.7\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_raylib&#34;, version = &#34;0.0.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_raylib/0.0.4">0.0.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_raylib\u0022, version = \u00220.0.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_raylib&#34;, version = &#34;0.0.20&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_raylib/0.0.20">0.0.20</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_raylib\u0022, version = \u00220.0.20\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_raylib&#34;, version = &#34;0.0.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_raylib/0.0.2">0.0.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_raylib\u0022, version = \u00220.0.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_raylib&#34;, version = &#34;0.0.19&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_raylib/0.0.19">0.0.19</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_raylib\u0022, version = \u00220.0.19\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_raylib&#34;, version = &#34;0.0.16&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_raylib/0.0.16">0.0.16</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_raylib\u0022, version = \u00220.0.16\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_raylib&#34;, version = &#34;0.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_raylib/0.0.1">0.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_raylib\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>bazel_skylib</code> (1.7.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>glew</code> (2.2.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>glfw</code> (3.3.9)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>glm</code> (1.0.0.bcr.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>googletest</code> (1.16.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>hermetic_cc_toolchain</code> (3.1.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>platforms</code> (0.0.11)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_cc</code> (0.1.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_foreign_cc</code> (0.14.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://github.com/filmil/bazel_rules_raylib">https://github.com/filmil/bazel_rules_raylib</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/bazel_rules_raylib">github:filmil/bazel_rules_raylib</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-bazel_rules_vivado">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							bazel_rules_vivado
+							<a href="https://github.com/filmil/bazel_rules_vivado"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;3.0.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/3.0.0">3.0.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00223.0.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;2.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/2.0.0">2.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00222.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;1.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/1.0.1">1.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00221.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;1.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/1.0.0">1.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.5.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.5.1">0.5.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.5.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.5.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.5.0">0.5.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.5.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.4.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.4.0">0.4.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.4.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.3.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.3.1">0.3.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.3.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.3.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.3.0">0.3.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.3.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.2.0">0.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.1.0">0.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.9&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.9">0.0.9</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.9\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.8&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.8">0.0.8</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.8\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.6&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.6">0.0.6</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.6\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.5">0.0.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.4">0.0.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.14&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.14">0.0.14</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.14\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.11&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.11">0.0.11</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.11\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazel_rules_vivado&#34;, version = &#34;0.0.10&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazel_rules_vivado/0.0.10">0.0.10</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazel_rules_vivado\u0022, version = \u00220.0.10\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>bazel_skylib</code> (1.8.2)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>fshlib</code> (0.2.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>gazelle</code> (0.45.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>gotopt2</code> (2.2.4)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_bid</code> (2.0.3)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_go</code> (0.59.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://github.com/filmil/bazel_rules_vivado">https://github.com/filmil/bazel_rules_vivado</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/bazel_rules_vivado">github:filmil/bazel_rules_vivado</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-bazoekt">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							bazoekt
+							<a href="https://github.com/filmil/bazoekt"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazoekt&#34;, version = &#34;0.1.7&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazoekt/0.1.7">0.1.7</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazoekt\u0022, version = \u00220.1.7\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazoekt&#34;, version = &#34;0.1.6&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazoekt/0.1.6">0.1.6</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazoekt\u0022, version = \u00220.1.6\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazoekt&#34;, version = &#34;0.1.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazoekt/0.1.5">0.1.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazoekt\u0022, version = \u00220.1.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazoekt&#34;, version = &#34;0.1.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazoekt/0.1.4">0.1.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazoekt\u0022, version = \u00220.1.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazoekt&#34;, version = &#34;0.1.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazoekt/0.1.3">0.1.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazoekt\u0022, version = \u00220.1.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazoekt&#34;, version = &#34;0.1.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazoekt/0.1.2">0.1.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazoekt\u0022, version = \u00220.1.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;bazoekt&#34;, version = &#34;0.1.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/bazoekt/0.1.1">0.1.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022bazoekt\u0022, version = \u00220.1.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>buildifier_prebuilt</code> (8.5.1.2)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>gazelle</code> (0.51.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>gotopt2</code> (2.3.3)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>protobuf</code> (34.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_android</code> (0.7.2)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_go</code> (0.60.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_pkg</code> (1.2.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_python</code> (2.0.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_shell</code> (0.8.0)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://github.com/filmil/bazoekt">https://github.com/filmil/bazoekt</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/bazoekt">github:filmil/bazoekt</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-elfutils">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							elfutils
+							<a href="https://github.com/filmil/bazel_elfutils"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;1.0.9&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/1.0.9">1.0.9</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00221.0.9\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;1.0.8&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/1.0.8">1.0.8</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00221.0.8\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;1.0.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/1.0.5">1.0.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00221.0.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;1.0.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/1.0.4">1.0.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00221.0.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;1.0.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/1.0.2">1.0.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00221.0.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;1.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/1.0.1">1.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00221.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;1.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/1.0.0">1.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.8&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.8">0.4.8</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.8\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.7&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.7">0.4.7</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.7\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.6&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.6">0.4.6</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.6\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.5">0.4.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.4">0.4.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.3">0.4.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.2">0.4.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.18&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.18">0.4.18</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.18\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.11&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.11">0.4.11</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.11\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.10&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.10">0.4.10</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.10\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.4.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.4.1">0.4.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.4.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.3.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.3.2">0.3.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.3.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.2.0">0.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.1.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.1.4">0.1.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.1.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.1.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.1.3">0.1.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.1.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.1.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.1.1">0.1.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.1.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.1.0">0.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;elfutils&#34;, version = &#34;0.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/elfutils/0.0.1">0.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022elfutils\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>gcc_toolchain</code> (0.9.0)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+                                
+                                    <li>
+                                        <code>platforms</code> (1.0.0)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_cc</code> (0.2.14)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_foreign_cc</code> (0.15.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_m4</code> (0.3)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>zlib</code> (1.3.1.bcr.7)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://github.com/filmil/bazel_elfutils">https://github.com/filmil/bazel_elfutils</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/bazel_elfutils">github:filmil/bazel_elfutils</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-fbzl">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							fbzl
+							<a href="#ZgotmplZ"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fbzl&#34;, version = &#34;0.0.5&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fbzl/0.0.5">0.0.5</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fbzl\u0022, version = \u00220.0.5\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fbzl&#34;, version = &#34;0.0.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fbzl/0.0.3">0.0.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fbzl\u0022, version = \u00220.0.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fbzl&#34;, version = &#34;0.0.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fbzl/0.0.2">0.0.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fbzl\u0022, version = \u00220.0.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fbzl&#34;, version = &#34;0.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fbzl/0.0.1">0.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fbzl\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>bazel_lib</code> (3.2.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>bazel_skylib_gazelle_plugin</code> (1.8.2)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>buildifier_prebuilt</code> (8.2.0.2)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>gazelle</code> (0.47.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>protobuf</code> (33.4)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_pkg</code> (1.1.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>stardoc</code> (0.8.1)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="#ZgotmplZ">https.://github.com/filmil/fbzl</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/fbzl">github:filmil/fbzl</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-fshlib">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							fshlib
+							<a href="https://github.com/filmil/fshlib"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.2.7&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.2.7">0.2.7</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.2.7\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.2.6&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.2.6">0.2.6</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.2.6\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.2.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.2.5">0.2.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.2.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.2.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.2.4">0.2.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.2.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.2.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.2.3">0.2.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.2.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.2.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.2.2">0.2.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.2.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.2.0">0.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.9&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.9">0.1.9</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.9\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.8&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.8">0.1.8</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.8\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.6&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.6">0.1.6</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.6\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.5">0.1.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.4">0.1.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.3">0.1.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.2">0.1.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.1.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.1.1">0.1.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.1.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;fshlib&#34;, version = &#34;0.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/fshlib/0.0.1">0.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022fshlib\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://github.com/filmil/fshlib">https://github.com/filmil/fshlib</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/fshlib">github:filmil/fshlib</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-futility">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							futility
+							<a href="https://github.com/filmil/futility"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.9&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.9">0.3.9</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.9\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.6&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.6">0.3.6</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.6\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.5">0.3.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.4">0.3.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.2">0.3.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.14&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.14">0.3.14</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.14\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.13&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.13">0.3.13</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.13\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.10&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.10">0.3.10</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.10\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.1">0.3.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.3.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.3.0">0.3.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.3.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.2.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.2.3">0.2.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.2.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.2.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.2.2">0.2.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.2.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.2.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.2.1">0.2.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.2.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.2.0">0.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;futility&#34;, version = &#34;0.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/futility/0.1.0">0.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022futility\u0022, version = \u00220.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>buildifier_prebuilt</code> (8.2.0.2)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>gazelle</code> (0.47.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_go</code> (0.57.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_multitool</code> (1.9.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_pkg</code> (1.0.1)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://github.com/filmil/futility">https://github.com/filmil/futility</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/futility">github:filmil/futility</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-gotopt2">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							gotopt2
+							<a href="https://github.com/filmil/gotopt2"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;gotopt2&#34;, version = &#34;2.6.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/gotopt2/2.6.0">2.6.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022gotopt2\u0022, version = \u00222.6.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;gotopt2&#34;, version = &#34;2.5.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/gotopt2/2.5.1">2.5.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022gotopt2\u0022, version = \u00222.5.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;gotopt2&#34;, version = &#34;2.3.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/gotopt2/2.3.3">2.3.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022gotopt2\u0022, version = \u00222.3.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;gotopt2&#34;, version = &#34;2.2.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/gotopt2/2.2.4">2.2.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022gotopt2\u0022, version = \u00222.2.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;gotopt2&#34;, version = &#34;2.2.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/gotopt2/2.2.2">2.2.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022gotopt2\u0022, version = \u00222.2.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;gotopt2&#34;, version = &#34;2.2.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/gotopt2/2.2.1">2.2.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022gotopt2\u0022, version = \u00222.2.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;gotopt2&#34;, version = &#34;2.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/gotopt2/2.2.0">2.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022gotopt2\u0022, version = \u00222.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;gotopt2&#34;, version = &#34;2.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/gotopt2/2.0.1">2.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022gotopt2\u0022, version = \u00222.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>bazel_bats</code> (0.38.23)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>bazel_lib</code> (3.0.0)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+                                
+                                    <li>
+                                        <code>bazel_skylib</code> (1.8.2)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+                                
+                                    <li>
+                                        <code>bazel_skylib_gazelle_plugin</code> (1.8.2)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+                                
+                                    <li>
+                                        <code>buildifier_prebuilt</code> (8.5.1.2)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>gazelle</code> (0.51.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>protobuf</code> (33.4)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_go</code> (0.60.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_multitool</code> (1.11.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_pkg</code> (1.2.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_shell</code> (0.8.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>stardoc</code> (0.8.1)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://github.com/filmil/gotopt2">https://github.com/filmil/gotopt2</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/gotopt2">github:filmil/gotopt2</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-graphviz">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							graphviz
+							<a href="https://github.com/filmil/bazel_graphviz_foreign"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;graphviz&#34;, version = &#34;0.0.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/graphviz/0.0.2">0.0.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022graphviz\u0022, version = \u00220.0.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>hermetic_cc_toolchain</code> (3.1.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_cc</code> (0.2.8)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_foreign_cc</code> (0.15.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>zlib_foreign</code> (0.0.1)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://github.com/filmil/bazel_graphviz_foreign">https://github.com/filmil/bazel_graphviz_foreign</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/bazel_graphviz_foreign">github:filmil/bazel_graphviz_foreign</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-graphviz_foreign">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							graphviz_foreign
+							<a href="https://github.com/filmil/bazel_graphviz_foreign"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;graphviz_foreign&#34;, version = &#34;0.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/graphviz_foreign/0.0.1">0.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022graphviz_foreign\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>hermetic_cc_toolchain</code> (3.1.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_cc</code> (0.2.8)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_foreign_cc</code> (0.15.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>zlib_foreign</code> (0.0.1)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://github.com/filmil/bazel_graphviz_foreign">https://github.com/filmil/bazel_graphviz_foreign</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/bazel_graphviz_foreign">github:filmil/bazel_graphviz_foreign</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-hello_foreign">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							hello_foreign
+							<a href="https://github.com/filmil/bazel_hello_foreign"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.6&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.6">0.0.6</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.6\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.5">0.0.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.4">0.0.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.25&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.25">0.0.25</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.25\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.24&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.24">0.0.24</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.24\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.21&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.21">0.0.21</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.21\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.19&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.19">0.0.19</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.19\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.15&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.15">0.0.15</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.15\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;hello_foreign&#34;, version = &#34;0.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/hello_foreign/0.0.1">0.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022hello_foreign\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>hermetic_cc_toolchain</code> (3.1.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_cc</code> (0.2.8)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_foreign_cc</code> (0.15.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>zlib_foreign</code> (0.0.1)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://github.com/filmil/bazel_hello_foreign">https://github.com/filmil/bazel_hello_foreign</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/bazel_hello_foreign">github:filmil/bazel_hello_foreign</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-libzstd">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							libzstd
+							<a href="https://github.com/filmil/bazel_elfutils"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;libzstd&#34;, version = &#34;0.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/libzstd/0.0.1">0.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022libzstd\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>hermetic_cc_toolchain</code> (3.1.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_cc</code> (0.2.8)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_foreign_cc</code> (0.15.1)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://github.com/filmil/bazel_elfutils">https://github.com/filmil/bazel_elfutils</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/bazel_elfutils">github:filmil/bazel_elfutils</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-libzstd_foreign">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							libzstd_foreign
+							<a href="https://github.com/filmil/bazel_libzstd"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;libzstd_foreign&#34;, version = &#34;0.0.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/libzstd_foreign/0.0.3">0.0.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022libzstd_foreign\u0022, version = \u00220.0.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;libzstd_foreign&#34;, version = &#34;0.0.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/libzstd_foreign/0.0.2">0.0.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022libzstd_foreign\u0022, version = \u00220.0.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>hermetic_cc_toolchain</code> (3.1.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_cc</code> (0.2.8)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_foreign_cc</code> (0.15.1)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://github.com/filmil/bazel_libzstd">https://github.com/filmil/bazel_libzstd</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/bazel_libzstd">github:filmil/bazel_libzstd</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-lit2md">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							lit2md
+							<a href="#ZgotmplZ"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.2.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.2.2">1.2.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.2.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.2.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.2.1">1.2.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.2.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.2.0">1.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.9&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.9">1.1.9</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.9\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.7&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.7">1.1.7</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.7\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.6&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.6">1.1.6</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.6\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.4">1.1.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.3">1.1.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.10&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.10">1.1.10</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.10\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.1">1.1.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.1.0">1.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.0.1">1.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;1.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/1.0.0">1.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;0.2.9&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/0.2.9">0.2.9</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00220.2.9\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;0.2.8&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/0.2.8">0.2.8</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00220.2.8\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;0.2.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/0.2.3">0.2.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00220.2.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;0.2.10&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/0.2.10">0.2.10</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00220.2.10\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;lit2md&#34;, version = &#34;0.1.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/lit2md/0.1.1">0.1.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022lit2md\u0022, version = \u00220.1.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>aspect_bazel_lib</code> (2.21.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>bazel_lib</code> (3.0.0)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+                                
+                                    <li>
+                                        <code>bazel_skylib</code> (1.8.2)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+                                
+                                    <li>
+                                        <code>bazel_skylib_gazelle_plugin</code> (1.8.2)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+                                
+                                    <li>
+                                        <code>buildifier_prebuilt</code> (8.2.0.2)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>gazelle</code> (0.47.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>protobuf</code> (33.4)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_go</code> (0.59.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_multitool</code> (1.9.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_pkg</code> (1.1.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>stardoc</code> (0.8.1)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="#ZgotmplZ">https.://github.com/filmil/lit2md</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/lit2md">github:filmil/lit2md</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-rules_bid">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							rules_bid
+							<a href="https://hdlfactory.com/post/2025/02/11/bazel-rules-for-build-in-docker-or-bid/"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.2.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.2.2">2.2.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.2.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.2.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.2.1">2.2.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.2.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.2.0">2.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.1.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.1.2">2.1.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.1.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.1.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.1.1">2.1.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.1.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.1.0">2.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.0.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.0.3">2.0.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.0.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.0.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.0.2">2.0.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.0.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bid&#34;, version = &#34;2.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bid/2.0.0">2.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bid\u0022, version = \u00222.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>aspect_bazel_lib</code> (2.22.5)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>bazel_lib</code> (3.3.1)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+                                
+                                    <li>
+                                        <code>bazel_skylib</code> (1.9.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>bazel_skylib_gazelle_plugin</code> (1.9.0)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+                                
+                                    <li>
+                                        <code>buildifier_prebuilt</code> (8.5.1.2)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>fshlib</code> (0.2.6)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>gazelle</code> (0.51.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>protobuf</code> (34.1)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_go</code> (0.60.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_multitool</code> (1.11.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_pkg</code> (1.2.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_shell</code> (0.8.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>stardoc</code> (0.8.1)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://hdlfactory.com/post/2025/02/11/bazel-rules-for-build-in-docker-or-bid/">https://hdlfactory.com/post/2025/02/11/bazel-rules-for-build-in-docker-or-bid/</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/bazel-rules-bid">github:filmil/bazel-rules-bid</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-rules_bt">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							rules_bt
+							<a href="https://www.hdlfactory.com"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.6&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.6">1.2.6</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.6\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.4">1.2.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.3">1.2.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.22&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.22">1.2.22</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.22\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.2">1.2.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.18&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.18">1.2.18</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.18\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.16&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.16">1.2.16</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.16\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.14&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.14">1.2.14</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.14\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.13&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.13">1.2.13</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.13\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.10&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.10">1.2.10</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.10\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.2.0">1.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_bt&#34;, version = &#34;1.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_bt/1.0.0">1.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_bt\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>bazel_lib</code> (3.0.0)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+                                
+                                    <li>
+                                        <code>bazel_skylib</code> (1.8.2)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+                                
+                                    <li>
+                                        <code>bazel_skylib_gazelle_plugin</code> (1.8.2)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+                                
+                                    <li>
+                                        <code>gazelle</code> (0.45.0)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_multitool</code> (1.8.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_pkg</code> (1.1.0)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://www.hdlfactory.com">https://www.hdlfactory.com</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/bazel_rules_bt">github:filmil/bazel_rules_bt</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-rules_fusesoc">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							rules_fusesoc
+							<a href="https://github.com/filmil/bazel_rules_fusesoc_2"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;1.0.3&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/1.0.3">1.0.3</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00221.0.3\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;1.0.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/1.0.2">1.0.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00221.0.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;1.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/1.0.1">1.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00221.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;1.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/1.0.0">1.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.9.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.9.0">0.9.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.9.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.8.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.8.0">0.8.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.8.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.10.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.10.4">0.10.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.10.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.10.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.10.3">0.10.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.10.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.10.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.10.0">0.10.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.10.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.1.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.1.2">0.1.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.1.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.1.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.1.1">0.1.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.1.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_fusesoc&#34;, version = &#34;0.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_fusesoc/0.0.1">0.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_fusesoc\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>bazel_rules_bid</code> (1.2.2)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>gazelle</code> (0.47.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_go</code> (0.59.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_pkg</code> (1.2.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_python</code> (1.6.3)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_shar</code> (0.5.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://github.com/filmil/bazel_rules_fusesoc_2">https://github.com/filmil/bazel_rules_fusesoc_2</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/bazel_rules_fusesoc_2">github:filmil/bazel_rules_fusesoc_2</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-rules_nvc">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							rules_nvc
+							<a href="https://github.com/filmil/bazel_rules_nvc"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.2.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.2.2">4.2.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.2.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.2.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.2.1">4.2.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.2.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.2.0">4.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.1.6&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.1.6">4.1.6</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.1.6\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.1.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.1.5">4.1.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.1.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.1.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.1.4">4.1.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.1.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.1.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.1.3">4.1.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.1.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.1.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.1.2">4.1.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.1.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.1.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.1.1">4.1.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.1.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.1.0">4.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.0.1">4.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;4.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/4.0.0">4.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00224.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;3.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/3.0.0">3.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00223.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;2.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/2.0.1">2.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00222.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;2.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/2.0.0">2.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00222.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;1.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/1.2.0">1.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00221.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;1.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/1.1.0">1.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00221.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;1.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/1.0.1">1.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00221.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_nvc&#34;, version = &#34;1.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_nvc/1.0.0">1.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_nvc\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>bazel_lib</code> (3.1.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>bazel_linux_packages</code> (0.3.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>bazel_skylib</code> (1.9.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>bazel_skylib_gazelle_plugin</code> (1.8.2)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>gazelle</code> (0.47.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>gotopt2</code> (2.2.2)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>platforms</code> (1.0.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>portable_cc_toolchain</code> (2025.12.16)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>protobuf</code> (34.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_android</code> (0.7.2)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_cc</code> (0.2.17)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_go</code> (0.60.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_shell</code> (0.8.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_verilator</code> (0.3.2)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_verilog</code> (1.1.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>stardoc</code> (0.8.1)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://github.com/filmil/bazel_rules_nvc">https://github.com/filmil/bazel_rules_nvc</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/bazel_rules_nvc">github:filmil/bazel_rules_nvc</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-rules_osvvm">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							rules_osvvm
+							<a href="https://github.com/filmil/bazel_rules_osvvm"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_osvvm&#34;, version = &#34;1.1.5&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_osvvm/1.1.5">1.1.5</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_osvvm\u0022, version = \u00221.1.5\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_osvvm&#34;, version = &#34;1.1.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_osvvm/1.1.4">1.1.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_osvvm\u0022, version = \u00221.1.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_osvvm&#34;, version = &#34;1.1.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_osvvm/1.1.3">1.1.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_osvvm\u0022, version = \u00221.1.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_osvvm&#34;, version = &#34;1.1.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_osvvm/1.1.2">1.1.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_osvvm\u0022, version = \u00221.1.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_osvvm&#34;, version = &#34;1.1.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_osvvm/1.1.1">1.1.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_osvvm\u0022, version = \u00221.1.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_osvvm&#34;, version = &#34;1.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_osvvm/1.1.0">1.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_osvvm\u0022, version = \u00221.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_osvvm&#34;, version = &#34;1.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_osvvm/1.0.0">1.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_osvvm\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>rules_nvc</code> (1.0.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>toolchains_llvm</code> (1.5.0)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://github.com/filmil/bazel_rules_osvvm">https://github.com/filmil/bazel_rules_osvvm</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/bazel_rules_osvvm">github:filmil/bazel_rules_osvvm</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-rules_shar">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							rules_shar
+							<a href="https://www.hdlfactory.com/post/2025/11/22/rules_shar-bazel-rules-for-creating-self-extracting-archives-shars/"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;1.0.7&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/1.0.7">1.0.7</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00221.0.7\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;1.0.6&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/1.0.6">1.0.6</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00221.0.6\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;1.0.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/1.0.5">1.0.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00221.0.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;1.0.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/1.0.4">1.0.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00221.0.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;1.0.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/1.0.3">1.0.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00221.0.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;1.0.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/1.0.2">1.0.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00221.0.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;1.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/1.0.0">1.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.5.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.5.4">0.5.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.5.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.5.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.5.2">0.5.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.5.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.5.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.5.1">0.5.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.5.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.5.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.5.0">0.5.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.5.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.4.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.4.2">0.4.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.4.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.4.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.4.1">0.4.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.4.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.4.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.4.0">0.4.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.4.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.3.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.3.2">0.3.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.3.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.3.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.3.1">0.3.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.3.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.3.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.3.0">0.3.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.3.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.2.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.2.1">0.2.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.2.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.2.0">0.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.1.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.1.2">0.1.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.1.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.1.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.1.1">0.1.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.1.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.1.0">0.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_shar&#34;, version = &#34;0.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_shar/0.0.1">0.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_shar\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>rules_pkg</code> (1.2.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://www.hdlfactory.com/post/2025/11/22/rules_shar-bazel-rules-for-creating-self-extracting-archives-shars/">https://www.hdlfactory.com/post/2025/11/22/rules_shar-bazel-rules-for-creating-self-extracting-archives-shars/</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/rules_shar">github:filmil/rules_shar</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-rules_vivado">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							rules_vivado
+							<a href="https://github.com/filmil/bazel_rules_vivado"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.5.0&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.5.0">3.5.0</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.5.0\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.4.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.4.5">3.4.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.4.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.4.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.4.4">3.4.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.4.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.4.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.4.3">3.4.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.4.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.4.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.4.2">3.4.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.4.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.4.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.4.1">3.4.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.4.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.4.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.4.0">3.4.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.4.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.3.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.3.1">3.3.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.3.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.3.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.3.0">3.3.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.3.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.2.0">3.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.1.0">3.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.0.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.0.2">3.0.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.0.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vivado&#34;, version = &#34;3.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vivado/3.0.1">3.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vivado\u0022, version = \u00223.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>bazel_lib</code> (3.2.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>bazel_skylib</code> (1.8.2)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>bazel_skylib_gazelle_plugin</code> (1.8.2)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+                                
+                                    <li>
+                                        <code>buildifier_prebuilt</code> (8.2.0.2)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>fshlib</code> (0.2.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>gazelle</code> (0.47.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>gotopt2</code> (2.2.4)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>protobuf</code> (33.4)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_bid</code> (2.2.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_go</code> (0.59.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>stardoc</code> (0.8.1)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://github.com/filmil/bazel_rules_vivado">https://github.com/filmil/bazel_rules_vivado</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/bazel_rules_vivado">github:filmil/bazel_rules_vivado</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-rules_vunit">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							rules_vunit
+							<a href="https://github.com/filmil/bazel_rules_vunit"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vunit&#34;, version = &#34;1.2.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vunit/1.2.2">1.2.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vunit\u0022, version = \u00221.2.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vunit&#34;, version = &#34;1.2.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vunit/1.2.1">1.2.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vunit\u0022, version = \u00221.2.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vunit&#34;, version = &#34;1.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vunit/1.2.0">1.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vunit\u0022, version = \u00221.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vunit&#34;, version = &#34;1.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vunit/1.1.0">1.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vunit\u0022, version = \u00221.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vunit&#34;, version = &#34;1.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vunit/1.0.1">1.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vunit\u0022, version = \u00221.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vunit&#34;, version = &#34;1.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vunit/1.0.0">1.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vunit\u0022, version = \u00221.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;rules_vunit&#34;, version = &#34;0.0.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/rules_vunit/0.0.2">0.0.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022rules_vunit\u0022, version = \u00220.0.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>rules_nvc</code> (1.2.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_osvvm</code> (1.1.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>toolchains_llvm</code> (1.5.0)
+                                        <span class="badge bg-secondary" style="font-size: 0.6em;">dev</span>
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://github.com/filmil/bazel_rules_vunit">https://github.com/filmil/bazel_rules_vunit</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/bazel_rules_vunit">github:filmil/bazel_rules_vunit</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-upspin">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							upspin
+							<a href="https://github.com/filmil/upspin"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;43.0.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/43.0.2">43.0.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002243.0.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;43.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/43.0.1">43.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002243.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;43.0.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/43.0.0">43.0.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002243.0.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;42.1.9&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/42.1.9">42.1.9</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002242.1.9\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;42.1.8&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/42.1.8">42.1.8</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002242.1.8\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;42.1.6&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/42.1.6">42.1.6</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002242.1.6\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;42.1.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/42.1.5">42.1.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002242.1.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin&#34;, version = &#34;42.1.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin/42.1.4">42.1.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin\u0022, version = \u002242.1.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>gazelle</code> (0.50.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>protobuf</code> (34.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_android</code> (0.7.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_go</code> (0.60.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_oci</code> (2.3.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_pkg</code> (1.0.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_proto</code> (7.1.0)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://github.com/filmil/upspin">https://github.com/filmil/upspin</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/upspin">github:filmil/upspin</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-upspin_drive">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							upspin_drive
+							<a href="https://github.com/filmil/upspin-gdrive"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin_drive&#34;, version = &#34;42.1.2&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin_drive/42.1.2">42.1.2</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin_drive\u0022, version = \u002242.1.2\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin_drive&#34;, version = &#34;42.1.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin_drive/42.1.1">42.1.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin_drive\u0022, version = \u002242.1.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;upspin_drive&#34;, version = &#34;0.1.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/upspin_drive/0.1.2">0.1.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022upspin_drive\u0022, version = \u00220.1.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>bazel_lib</code> (3.0.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>gazelle</code> (0.50.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>platforms</code> (1.0.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_go</code> (0.60.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_oci</code> (2.2.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_pkg</code> (1.0.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>upspin</code> (43.0.1)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://github.com/filmil/upspin-gdrive">https://github.com/filmil/upspin-gdrive</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/upspin-gdrive">github:filmil/upspin-gdrive</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-vhdl_ls_gen">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							vhdl_ls_gen
+							<a href="https://github.com/filmil/bazel_vhdl_ls_gen"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.3.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.3.1">0.3.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.3.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.3.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.3.0">0.3.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.3.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.2.6&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.2.6">0.2.6</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.2.6\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.2.5&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.2.5">0.2.5</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.2.5\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.2.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.2.4">0.2.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.2.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.2.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.2.3">0.2.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.2.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.2.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.2.1">0.2.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.2.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.2.0">0.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.1.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.1.2">0.1.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.1.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.1.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.1.1">0.1.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.1.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.1.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.1.0">0.1.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.1.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.0.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.0.2">0.0.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.0.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;vhdl_ls_gen&#34;, version = &#34;0.0.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/vhdl_ls_gen/0.0.1">0.0.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022vhdl_ls_gen\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>bazel_lib</code> (3.1.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>bazel_skylib</code> (1.8.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://github.com/filmil/bazel_vhdl_ls_gen">https://github.com/filmil/bazel_vhdl_ls_gen</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/bazel_vhdl_ls_gen">github:filmil/bazel_vhdl_ls_gen</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-xrootfs">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							xrootfs
+							<a href="https://github.com/filmil/xrootfs"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.9&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.9">0.2.9</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.9\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                                    <details>
+                                        <summary class="text-muted" style="cursor: pointer; font-size: 0.9em;">Older versions</summary>
+                                        <div class="mt-2">
+                                        
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.3">0.2.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.21&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.21">0.2.21</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.21\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.2&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.2">0.2.2</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.2\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.17&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.17">0.2.17</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.17\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.11&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.11">0.2.11</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.11\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.1&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.1">0.2.1</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.1\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.2.0&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.2.0">0.2.0</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.2.0\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.1.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.1.4">0.1.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.1.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.1.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.1.3">0.1.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.1.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.0.4&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.0.4">0.0.4</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.0.4\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                            
+                                                
+                                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;xrootfs&#34;, version = &#34;0.0.3&#34;)">
+                                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/xrootfs/0.0.3">0.0.3</a>
+                                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022xrootfs\u0022, version = \u00220.0.3\u0022)'); return false;">
+                                                            <i class="bi bi-clipboard"></i>
+                                                        </a>
+                                                    </span>
+                                                
+                                            
+                                        
+                                        </div>
+                                    </details>
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>buildifier_prebuilt</code> (8.2.0.2)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>gazelle</code> (0.45.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_go</code> (0.57.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_multitool</code> (1.9.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_pkg</code> (1.0.1)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_shell</code> (0.6.1)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://github.com/filmil/xrootfs">https://github.com/filmil/xrootfs</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/xrootfs">github:filmil/xrootfs</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+            <div class="col-md-4 mb-4 module-card" id="card-zlib_foreign">
+                <div class="card">
+                    <div class="card-body">
+                        <h5 class="card-title">
+							zlib_foreign
+							<a href="https://github.com/filmil/bazel_zlib_foreign"><i class="bi bi-link-45deg"></i></a>
+						</h5>
+                        <div class="card-text mb-2">
+                            <strong>Versions:</strong>
+                            
+                                
+                                
+                                    <span class="me-2" data-bs-toggle="tooltip" data-bs-placement="top" title="bazel_dep(name = &#34;zlib_foreign&#34;, version = &#34;0.0.1&#34;)">
+                                        <a href="https://github.com/filmil/bazel-registry/tree/main/modules/zlib_foreign/0.0.1">0.0.1</a>
+                                        <a href="#" onclick="copyToClipboard('bazel_dep(name = \u0022zlib_foreign\u0022, version = \u00220.0.1\u0022)'); return false;">
+                                            <i class="bi bi-clipboard"></i>
+                                        </a>
+                                    </span>
+                                
+
+                                
+                            
+                        </div>
+                        
+                            
+                            
+                                <details>
+                                <summary class="card-text mb-1"><strong>Dependencies (Latest):</strong></summary>
+                                <ul class="list-unstyled mb-2 ms-2">
+                                
+                                    <li>
+                                        <code>hermetic_cc_toolchain</code> (3.1.0)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_cc</code> (0.2.8)
+                                        
+                                    </li>
+                                
+                                    <li>
+                                        <code>rules_foreign_cc</code> (0.15.1)
+                                        
+                                    </li>
+                                
+                                </ul>
+                                </details>
+                            
+                        
+                        <details>
+                        <summary class="card-text mb-1"><strong>Links:</strong></summary>
+                        <ul class="list-unstyled mb-2 ms-2">
+                            <li><a href="https://github.com/filmil/bazel_zlib_foreign">https://github.com/filmil/bazel_zlib_foreign</a></li>
+                            <li>
+                                
+                                <a href="https://github.com/filmil/bazel_zlib_foreign">github:filmil/bazel_zlib_foreign</a>
+                            </li>
+                        </ul>
+                        </details>
+                    </div>
+                </div>
+            </div>
+            
+        </div>
+
+		<div class="mt-5">
+			<h3>Module Dependency DAG (Latest Versions)</h3>
+			<div id="mermaid-container">
+				<div id="mermaid-zoom-controls">
+					<button class="btn btn-sm btn-secondary" onclick="panZoom.zoomIn()"><i class="bi bi-plus-lg"></i></button>
+					<button class="btn btn-sm btn-secondary" onclick="panZoom.zoomOut()"><i class="bi bi-dash-lg"></i></button>
+					<button class="btn btn-sm btn-secondary" onclick="panZoom.reset()"><i class="bi bi-arrows-fullscreen"></i></button>
+				</div>
+				<div class="mermaid" id="dag-mermaid">
+					%%{init: {"flowchart": {"defaultRenderer": "elk"}} }%%
+graph TB
+    ExternalModules["aspect_bazel_lib (2.22.5)
+bazel_lib (3.1.0)
+bazel_linux_packages (0.3.1)
+bazel_skylib (1.8.1)
+bazel_skylib_gazelle_plugin (1.8.2)
+buildifier_prebuilt (8.2.0.2)
+gazelle (0.45.0)
+gcc_toolchain (0.9.0)
+glew (2.2.0)
+glfw (3.3.9)
+glm (1.0.0.bcr.1)
+googletest (1.16.0)
+hermetic_cc_toolchain (3.1.0)
+libffi (3.4.7.bcr.3)
+platforms (1.0.0)
+portable_cc_toolchain (2025.12.16)
+protobuf (34.1)
+rules_android (0.7.1)
+rules_cc (0.2.8)
+rules_distroless (0.8.0)
+rules_foreign_cc (0.15.1)
+rules_go (0.57.0)
+rules_m4 (0.3)
+rules_multitool (1.9.0)
+rules_oci (2.2.0)
+rules_pkg (1.0.1)
+rules_proto (7.1.0)
+rules_python (1.6.3)
+rules_python_gazelle_plugin (1.8.0)
+rules_shell (0.6.1)
+rules_verilator (0.3.2)
+rules_verilog (1.1.1)
+rules_zstd (1.0.0)
+stardoc (0.8.1)
+toolchains_llvm (1.5.0)
+zlib (1.3.1.bcr.7)
+zstd (1.5.7)"]
+    class ExternalModules inverted
+    bazel_go_basic["bazel-go-basic
+0.2.21"]
+    bazel_go_basic -- "jump" --> ExternalModules
+    class bazel_go_basic leaf
+    bazel_bats["bazel_bats
+0.38.23"]
+    bazel_bats -- "jump" --> ExternalModules
+    class bazel_bats leaf
+    bazel_debian_rootfs["bazel_debian_rootfs
+0.0.1"]
+    bazel_rules_bid["bazel_rules_bid
+1.4.0"]
+    bazel_debian_rootfs -- "jump" --> bazel_rules_bid
+    bazel_debian_rootfs -- "jump" --> ExternalModules
+    gotopt2["gotopt2
+2.6.0"]
+    bazel_debian_rootfs -- "jump" --> gotopt2
+    bazel_ebook["bazel_ebook
+2.0.15"]
+    bazel_ebook -- "jump" --> bazel_bats
+    bazel_ebook -- "jump" --> bazel_rules_bid
+    bazel_ebook -- "jump" --> ExternalModules
+    bazel_rootfs["bazel_rootfs
+1.0.3"]
+    bazel_rootfs -- "jump" --> bazel_rules_bid
+    bazel_rootfs -- "jump" --> ExternalModules
+    bazel_rootfs -- "jump" --> gotopt2
+    bazel_rules_bid -- "jump" --> ExternalModules
+    fshlib["fshlib
+0.2.7"]
+    bazel_rules_bid -- "jump" --> fshlib
+    bazel_rules_bt["bazel_rules_bt
+0.0.3"]
+    bazel_rules_bt -- "jump" --> ExternalModules
+    class bazel_rules_bt leaf
+    bazel_rules_ghdl["bazel_rules_ghdl
+1.0.0"]
+    bazel_rules_ghdl -- "jump" --> bazel_rules_bid
+    bazel_rules_ghdl -- "jump" --> ExternalModules
+    bazel_rules_ghdl -- "jump" --> gotopt2
+    bazel_rules_nvc["bazel_rules_nvc
+0.5.2"]
+    bazel_rules_nvc -- "jump" --> ExternalModules
+    elfutils["elfutils
+1.0.9"]
+    bazel_rules_nvc -- "jump" --> elfutils
+    bazel_rules_nvc -- "jump" --> fshlib
+    bazel_rules_nvc -- "jump" --> gotopt2
+    bazel_rules_osvvm["bazel_rules_osvvm
+0.0.1"]
+    bazel_rules_osvvm -- "jump" --> bazel_rules_nvc
+    bazel_rules_osvvm -- "jump" --> ExternalModules
+    bazel_rules_raylib["bazel_rules_raylib
+0.0.7"]
+    bazel_rules_raylib -- "jump" --> ExternalModules
+    class bazel_rules_raylib leaf
+    bazel_rules_vivado["bazel_rules_vivado
+3.0.0"]
+    bazel_rules_vivado -- "jump" --> ExternalModules
+    bazel_rules_vivado -- "jump" --> fshlib
+    bazel_rules_vivado -- "jump" --> gotopt2
+    rules_bid["rules_bid
+2.2.2"]
+    bazel_rules_vivado -- "jump" --> rules_bid
+    bazoekt["bazoekt
+0.1.7"]
+    bazoekt -- "jump" --> ExternalModules
+    bazoekt -- "jump" --> gotopt2
+    elfutils -- "jump" --> ExternalModules
+    class elfutils leaf
+    fbzl["fbzl
+0.0.5"]
+    fbzl -- "jump" --> ExternalModules
+    class fbzl leaf
+    fshlib -- "jump" --> ExternalModules
+    class fshlib leaf
+    futility["futility
+0.3.9"]
+    futility -- "jump" --> ExternalModules
+    class futility leaf
+    gotopt2 -- "jump" --> bazel_bats
+    gotopt2 -- "jump" --> ExternalModules
+    graphviz["graphviz
+0.0.2"]
+    graphviz -- "jump" --> ExternalModules
+    zlib_foreign["zlib_foreign
+0.0.1"]
+    graphviz -- "jump" --> zlib_foreign
+    graphviz_foreign["graphviz_foreign
+0.0.1"]
+    graphviz_foreign -- "jump" --> ExternalModules
+    graphviz_foreign -- "jump" --> zlib_foreign
+    hello_foreign["hello_foreign
+0.0.6"]
+    hello_foreign -- "jump" --> ExternalModules
+    hello_foreign -- "jump" --> zlib_foreign
+    libzstd["libzstd
+0.0.1"]
+    libzstd -- "jump" --> ExternalModules
+    class libzstd leaf
+    libzstd_foreign["libzstd_foreign
+0.0.3"]
+    libzstd_foreign -- "jump" --> ExternalModules
+    class libzstd_foreign leaf
+    lit2md["lit2md
+1.2.2"]
+    lit2md -- "jump" --> ExternalModules
+    class lit2md leaf
+    rules_bid -- "jump" --> ExternalModules
+    rules_bid -- "jump" --> fshlib
+    rules_bt["rules_bt
+1.2.6"]
+    rules_bt -- "jump" --> ExternalModules
+    class rules_bt leaf
+    rules_fusesoc["rules_fusesoc
+1.0.3"]
+    rules_fusesoc -- "jump" --> bazel_rules_bid
+    rules_fusesoc -- "jump" --> ExternalModules
+    rules_shar["rules_shar
+1.0.7"]
+    rules_fusesoc -- "jump" --> rules_shar
+    rules_nvc["rules_nvc
+4.2.2"]
+    rules_nvc -- "jump" --> ExternalModules
+    rules_nvc -- "jump" --> gotopt2
+    rules_osvvm["rules_osvvm
+1.1.5"]
+    rules_osvvm -- "jump" --> rules_nvc
+    rules_osvvm -- "jump" --> ExternalModules
+    rules_shar -- "jump" --> ExternalModules
+    class rules_shar leaf
+    rules_vivado["rules_vivado
+3.5.0"]
+    rules_vivado -- "jump" --> ExternalModules
+    rules_vivado -- "jump" --> fshlib
+    rules_vivado -- "jump" --> gotopt2
+    rules_vivado -- "jump" --> rules_bid
+    rules_vunit["rules_vunit
+1.2.2"]
+    rules_vunit -- "jump" --> rules_nvc
+    rules_vunit -- "jump" --> rules_osvvm
+    rules_vunit -- "jump" --> ExternalModules
+    upspin["upspin
+43.0.2"]
+    upspin -- "jump" --> ExternalModules
+    class upspin leaf
+    upspin_drive["upspin_drive
+42.1.2"]
+    upspin_drive -- "jump" --> ExternalModules
+    upspin_drive -- "jump" --> upspin
+    vhdl_ls_gen["vhdl_ls_gen
+0.3.1"]
+    vhdl_ls_gen -- "jump" --> ExternalModules
+    class vhdl_ls_gen leaf
+    xrootfs["xrootfs
+0.2.9"]
+    xrootfs -- "jump" --> ExternalModules
+    class xrootfs leaf
+    zlib_foreign -- "jump" --> ExternalModules
+    class zlib_foreign leaf
+    click bazel_rules_osvvm "#card-bazel_rules_osvvm"
+    click futility "#card-futility"
+    click graphviz "#card-graphviz"
+    click rules_shar "#card-rules_shar"
+    click fshlib "#card-fshlib"
+    click libzstd_foreign "#card-libzstd_foreign"
+    click rules_bt "#card-rules_bt"
+    click upspin "#card-upspin"
+    click lit2md "#card-lit2md"
+    click bazel_rules_bid "#card-bazel_rules_bid"
+    click bazel_rules_ghdl "#card-bazel_rules_ghdl"
+    click vhdl_ls_gen "#card-vhdl_ls_gen"
+    click xrootfs "#card-xrootfs"
+    click gotopt2 "#card-gotopt2"
+    click bazel_ebook "#card-bazel_ebook"
+    click bazel_go_basic "#card-bazel_go_basic"
+    click bazel_bats "#card-bazel_bats"
+    click elfutils "#card-elfutils"
+    click bazoekt "#card-bazoekt"
+    click zlib_foreign "#card-zlib_foreign"
+    click rules_osvvm "#card-rules_osvvm"
+    click upspin_drive "#card-upspin_drive"
+    click bazel_debian_rootfs "#card-bazel_debian_rootfs"
+    click bazel_rules_nvc "#card-bazel_rules_nvc"
+    click bazel_rules_vivado "#card-bazel_rules_vivado"
+    click hello_foreign "#card-hello_foreign"
+    click rules_fusesoc "#card-rules_fusesoc"
+    click rules_nvc "#card-rules_nvc"
+    click rules_vivado "#card-rules_vivado"
+    click bazel_rootfs "#card-bazel_rootfs"
+    click bazel_rules_bt "#card-bazel_rules_bt"
+    click rules_bid "#card-rules_bid"
+    click fbzl "#card-fbzl"
+    click graphviz_foreign "#card-graphviz_foreign"
+    click libzstd "#card-libzstd"
+    click rules_vunit "#card-rules_vunit"
+    click bazel_rules_raylib "#card-bazel_rules_raylib"
+    classDef inverted fill:#333,color:#fff
+    classDef leaf fill:#28a745,color:#fff
+
+				</div>
+			</div>
+		</div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/js/bootstrap.bundle.min.js"></script>
+	<script type="module">
+		import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+		mermaid.initialize({ 
+            startOnLoad: false,
+            flowchart: { useMaxWidth: false }
+        });
+
+        
+        window.panZoom = null;
+
+        async function initMermaid() {
+            const container = document.getElementById('dag-mermaid');
+            const { svg } = await mermaid.render('dag-svg', container.textContent);
+            container.innerHTML = svg;
+
+            const svgElement = container.querySelector('svg');
+            svgElement.removeAttribute('height');
+            svgElement.removeAttribute('width');
+            svgElement.style.width = '100%';
+            svgElement.style.height = '100%';
+            svgElement.style.maxWidth = '100%';
+
+            window.panZoom = svgPanZoom(svgElement, {
+                zoomEnabled: true,
+                controlIconsEnabled: true,
+                fit: true,
+                center: true,
+                minZoom: 0.01,
+                maxZoom: 50,
+                refreshRate: 'auto',
+            });
+
+            
+            window.panZoom.resize();
+            window.panZoom.fit();
+            window.panZoom.center();
+            
+            
+            window.addEventListener('resize', () => {
+                window.panZoom.resize();
+                window.panZoom.fit();
+                window.panZoom.center();
+            });
+        }
+
+        document.addEventListener('DOMContentLoaded', () => {
+            initMermaid();
+        });
+	</script>
+    <script>
+        const searchInput = document.getElementById('searchInput');
+        const moduleCards = document.querySelectorAll('.module-card');
+
+        searchInput.addEventListener('keyup', (event) => {
+            const filter = event.target.value.toLowerCase();
+            moduleCards.forEach(card => {
+                const title = card.querySelector('.card-title').textContent.toLowerCase();
+                if (title.includes(filter)) {
+                    card.style.display = '';
+                } else {
+                    card.style.display = 'none';
+                }
+            });
+        });
+
+        const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
+        const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl));
+
+        function copyToClipboard(text) {
+            navigator.clipboard.writeText(text).then(function() {
+                 
+            }, function() {
+                 
+                alert('Failed to copy');
+            });
+        }
+    </script>
+    <footer class="text-center mt-4 py-3">
+        <p>&copy; 2025-present Filip Filmar. All rights reserved.</p>
+        <p><small>This page was generated by an automated coding assistant.</small></p>
+    </footer>
+</body>
+</html>

--- a/modules/BUILD.bazel
+++ b/modules/BUILD.bazel
@@ -9,8 +9,7 @@ genrule(
     srcs = [
         "//modules:all_modules",
     ],
-    outs = [ "index.html"],
-    visibility = ["//visibility:public"],
+    outs = ["index.html"],
     cmd = """
     $(location //cmd/generate) \
         --modules_dir=modules \
@@ -19,4 +18,5 @@ genrule(
     tools = [
         "//cmd/generate",
     ],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
This pull request fixes the issue where module versions were not being rendered on a new line in the Mermaid DAG.

### Changes:
- **Node Shape Change**: Switched from round brackets `(...)` to square brackets `[...]` for Mermaid nodes. This is required by some Mermaid renderers (especially ELK) to correctly support multi-line text labels.
- **Literal Newlines**: Replaced `<br/>` with literal newlines (`\n`) within the labels.
- **Maintenance**: Updated the project's tests to reflect these syntax changes.

This pull request has been created by an automated coding assistant, with
human supervision.

Original prompt:
this does not result in a newline rendered between the name and the version: bazel_rules_raylib("bazel_rules_raylib<br/>0.0.7"). Fix mermaid diagram generation so that the version is rendered *below* the name, for this label and all others