### PR TITLE
fix: configure elk layout and use flowchart for mermaid

### DIFF
--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -111,12 +111,13 @@ func run(modulesDir, outputFile, mode string) error {
 func buildMermaid(modules []Module) string {
 	var sb strings.Builder
 	sb.WriteString(`---
-layout: elk
-elk:
+config:
+  layout: elk
+  elk:
     mergeEdges: true
 ---
 `)
-	sb.WriteString("graph TB\n")
+	sb.WriteString("flowchart TB\n")
 
 	registryLatest := make(map[string]string)
 	for _, m := range modules {


### PR DESCRIPTION
Fix Mermaid ELK layout configuration and change diagram type from graph to flowchart to correctly merge equivalent edges.

This pull request has been created by an automated coding assistant, with human supervision.
Prompt: modify buildMermaid function in @cmd/generate/main.go so that it uses elk for layout *and* it merges equivalent edges, I tried with adding a prefix, but that didn't work out
