### PR TITLE
Publish graphviz@0.0.38

### DIFF
--- a/modules/graphviz/0.0.38/MODULE.bazel
+++ b/modules/graphviz/0.0.38/MODULE.bazel
@@ -1,0 +1,35 @@
+module(
+    name = "graphviz",
+    version = "0.0.38",
+)
+
+bazel_dep(name = "rules_cc", version = "0.2.8")
+bazel_dep(name = "zlib", version = "1.3.1.bcr.7")
+bazel_dep(name = "rules_shell", version = "0.6.1")
+
+bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2", dev_dependency = True)
+
+bazel_dep(name = "hermetic_cc_toolchain", version = "3.1.0")
+
+toolchains = use_extension("@hermetic_cc_toolchain//toolchain:ext.bzl", "toolchains")
+use_repo(toolchains, "zig_sdk")
+
+register_toolchains(
+    "@zig_sdk//toolchain/...",
+    "@zig_sdk//libc_aware/toolchain/...",
+)
+
+http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "src",
+    build_file = "//:src.BUILD.bazel",
+    integrity = "sha256-rT9lTV1OHR5b5khvrTEG3FTo0yD7eIn3XZ05JT0uPYc=",
+    patch_strip = 1,
+    patches = [
+    ],
+    strip_prefix = "graphviz-14.0.0",
+    urls = [
+        "https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/14.0.0/graphviz-14.0.0.tar.gz",
+    ],
+)

--- a/modules/graphviz/0.0.38/patches/module_dot_bazel_version.patch
+++ b/modules/graphviz/0.0.38/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,7 @@
+ module(
+     name = "graphviz",
+-    version = "0.0.0",
++    version = "0.0.38",
+ )
+ 
+ bazel_dep(name = "rules_cc", version = "0.2.8")
+ bazel_dep(name = "zlib", version = "1.3.1.bcr.7")

--- a/modules/graphviz/0.0.38/presubmit.yml
+++ b/modules/graphviz/0.0.38/presubmit.yml
@@ -1,0 +1,18 @@
+bcr_test_module:
+  module_path: "integration"
+  matrix:
+    platform: ["ubuntu2204"]
+    bazel: [8.x]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."
+    verify_targets:
+      name: Verify build targets
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "@graphviz//:graphviz"

--- a/modules/graphviz/0.0.38/source.json
+++ b/modules/graphviz/0.0.38/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-nQHIQCc55s29iXR0o2TtoAhcwTMeZ9SUnP9AC/kbbTo=",
+    "strip_prefix": "",
+    "url": "https://github.com/filmil/bazel_graphviz/releases/download/v0.0.38/bazel_graphviz-v0.0.38.zip",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-melLZdFo/rpY/xYPXFlv2N0J3pSy8i7v4ntFAsSzIyY="
+    },
+    "patch_strip": 1
+}

--- a/modules/graphviz/metadata.json
+++ b/modules/graphviz/metadata.json
@@ -12,7 +12,8 @@
         "github:filmil/bazel_graphviz_foreign"
     ],
     "versions": [
-        "0.0.2"
+        "0.0.2",
+        "0.0.38"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/filmil/bazel_graphviz/releases/tag/v0.0.38

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_