### PR TITLE
chore: upgrade bazel_dep versions

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -3,9 +3,9 @@ module(
     version = "0.0.0",
 )
 
-bazel_dep(name = "rules_go", version = "0.60.0")
+bazel_dep(name = "rules_go", version = "0.61.1")
 bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2")
-bazel_dep(name = "gazelle", version = "0.51.0")
-bazel_dep(name = "bazel_lib", version = "3.2.1")
-bazel_dep(name = "rules_cc", version = "0.2.17")
-bazel_dep(name = "rules_android", version = "0.1.1")
+bazel_dep(name = "gazelle", version = "0.51.3")
+bazel_dep(name = "bazel_lib", version = "3.3.1")
+bazel_dep(name = "rules_cc", version = "0.2.19")
+bazel_dep(name = "rules_android", version = "0.7.3")


### PR DESCRIPTION
This PR upgrades bazel_dep versions in MODULE.bazel to the latest available in the BCR.

* rules_go: 0.60.0 -> 0.61.1
* gazelle: 0.51.0 -> 0.51.3
* bazel_lib: 3.2.1 -> 3.3.1
* rules_cc: 0.2.17 -> 0.2.19
* rules_android: 0.1.1 -> 0.7.3