### PR TITLE
Add nvc 1.22.0.bcr.1: FST wave-dump length guard

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,3 +1,4 @@
 modules/nvc/1.22.0.bcr.0/overlay
+modules/nvc/1.22.0.bcr.1/overlay
 modules/opensbi/1.6/overlay
 modules/*


### PR DESCRIPTION
## Problem
NVC's FST waveform writer (`src/rt/wave.c` `fst_fmt_chars`) segfaults when dumping a signal whose array length is mis-computed by `fst_get_array_range`. On the Gaisler NOEL-V (`noelvsys`) design under `bazel test … --wave`, one signal gets a length of ~3.95e9 (a stray pointer value), so `fst_fmt_chars` builds a multi-GB stack VLA `char buf[data->size]` and reads past the signal storage → SIGSEGV. Several other signals (`PMA_IDX`, `H_CTX_REPL`, `MASK`, `WFI_PC`, …) hit the same mis-read.

## Fix
`wave_fst_length_guard.patch`: in `fst_create_array_var`'s char-mapped branch, validate the computed length against `signal_width(s)` and skip the signal (warning names it) if it disagrees. No false positives — a normal `std_logic_vector` has `length == signal_width`.

## Details
- Same upstream nvc `@324ed157` tarball + overlay as `1.22.0.bcr.0`; adds one patch alongside `disable_test_ffold.patch`, and `modules/nvc/1.22.0.bcr.1/overlay` to `.bazelignore` (matching the other module overlays).
- Validated end-to-end: with this version the NOEL-V boot sim runs to completion (`SIMDONE`, `1 test passes`) with no segfault.
- Identical source fix upstreamed to filmil/nvc#5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_01BtpejRcfGU3fWf4KJk4fzd