### PR TITLE
rules_dtc@0.0.2

### DIFF
--- a/modules/rules_dtc/0.0.2/MODULE.bazel
+++ b/modules/rules_dtc/0.0.2/MODULE.bazel
@@ -1,0 +1,21 @@
+module(
+    name = "rules_dtc",
+    version = "0.0.2",
+    bazel_compatibility = [">=8.0.0"],
+    compatibility_level = 1,
+)
+
+# The Device Tree Compiler toolchain (provides @dtc//:dtc, @dtc//:fdtoverlay,
+# @dtc//:fdtdump, @dtc//:fdtget, @dtc//:fdtput, ...).
+bazel_dep(name = "dtc", version = "1.7.2.bcr.1")
+bazel_dep(name = "bazel_skylib", version = "1.9.0")
+bazel_dep(name = "bazel_lib", version = "3.3.1")
+
+# Documentation generation and linting.
+bazel_dep(name = "stardoc", version = "0.8.1", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "8.5.1.2", dev_dependency = True)
+
+# Pulled in transitively by stardoc. Pin a recent version so the build can use a
+# prebuilt protoc instead of compiling it from source (see .bazelrc); the older
+# transitively-selected version compiles protoc, which takes minutes.
+bazel_dep(name = "protobuf", version = "35.1", dev_dependency = True)

--- a/modules/rules_dtc/0.0.2/patches/module_dot_bazel_version.patch
+++ b/modules/rules_dtc/0.0.2/patches/module_dot_bazel_version.patch
@@ -1,0 +1,12 @@
+===================================================================
+--- a/MODULE.bazel
++++ b/MODULE.bazel
+@@ -1,7 +1,7 @@
+ module(
+     name = "rules_dtc",
+-    version = "0.0.0",
++    version = "0.0.2",
+     bazel_compatibility = [">=8.0.0"],
+     compatibility_level = 1,
+ )
+ 

--- a/modules/rules_dtc/0.0.2/presubmit.yml
+++ b/modules/rules_dtc/0.0.2/presubmit.yml
@@ -1,0 +1,18 @@
+bcr_test_module:
+  module_path: "integration"
+  matrix:
+    platform: ["ubuntu2204"]
+    bazel: ["8.x", "9.x"]
+  tasks:
+    run_tests:
+      name: "Run test module"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      test_targets:
+        - "//..."
+    verify_targets:
+      name: "Verify the dtc toolchain builds"
+      platform: ${{ platform }}
+      bazel: ${{ bazel }}
+      build_targets:
+        - "@dtc//:dtc"

--- a/modules/rules_dtc/0.0.2/source.json
+++ b/modules/rules_dtc/0.0.2/source.json
@@ -1,0 +1,9 @@
+{
+    "integrity": "sha256-mvxtYbOLvto/tPLEGsHVGkGnoKegntHk+aMMyrUyAO0=",
+    "strip_prefix": "",
+    "url": "https://github.com/filmil/bazel_rules_dtc/releases/download/v0.0.2/bazel_rules_dtc-v0.0.2.zip",
+    "patches": {
+        "module_dot_bazel_version.patch": "sha256-waqQkhsRberoDLSzhTl7bNwWGuVx/rDg6kjcqGIaH24="
+    },
+    "patch_strip": 1
+}

--- a/modules/rules_dtc/metadata.json
+++ b/modules/rules_dtc/metadata.json
@@ -12,7 +12,8 @@
         "github:filmil/bazel_rules_dtc"
     ],
     "versions": [
-        "0.0.1"
+        "0.0.1",
+        "0.0.2"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
Release: https://github.com/filmil/bazel_rules_dtc/releases/tag/v0.0.2

_Automated by [Publish to BCR](https://github.com/bazel-contrib/publish-to-bcr)_