### PR TITLE
feat: add texlive_bundle 1.0.0

### DIFF
--- a/modules/texlive_bundle/1.0.0/MODULE.bazel
+++ b/modules/texlive_bundle/1.0.0/MODULE.bazel
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+module(
+    name = "texlive_bundle",
+    version = "1.0.0",
+    compatibility_level = 1,
+)
+
+# For //latex:toolchain.bzl (the `latex_toolchain` rule) and the toolchain
+# type the bound toolchain implements.
+bazel_dep(name = "rules_latex_host", version = "0.1.0")
+
+# For the exec constraints on the toolchain (@platforms//os:linux, ...).
+bazel_dep(name = "platforms", version = "0.0.11")

--- a/modules/texlive_bundle/1.0.0/source.json
+++ b/modules/texlive_bundle/1.0.0/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-V5m2FHJ6IwtKB5mTN0+lzc6Fewlr6vwe5gOvz8gGYeU=",
+    "strip_prefix": "texlive_bundle-v1.0.0",
+    "url": "https://github.com/filmil/texlive-bundle/releases/download/v1.0.0/texlive_bundle-v1.0.0.tar.xz"
+}

--- a/modules/texlive_bundle/metadata.json
+++ b/modules/texlive_bundle/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/filmil/texlive-bundle",
+    "maintainers": [
+        {
+            "name": "Filip Filmar",
+            "email": "246576+filmil@users.noreply.github.com",
+            "github": "filmil",
+            "github_user_id": 246576
+        }
+    ],
+    "repository": [
+        "github:filmil/texlive-bundle"
+    ],
+    "versions": [
+        "1.0.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
A complete hermetic LaTeX toolchain (TeX tree, qpdf, ghostscript, and
the rules_latex_host toolchain wiring) as one module archive. Source:
https://github.com/filmil/texlive-bundle, release v1.0.0.

This commit has been created by an automated coding assistant, with human
supervision.

Prompt: "can you configure texlive-bundle to be a repository in my
registry?"