### PR TITLE
feat: publish rules_hugo 0.1.0 (overlay over stackb/rules_hugo)

### DIFF
--- a/modules/rules_hugo/0.1.0/MODULE.bazel
+++ b/modules/rules_hugo/0.1.0/MODULE.bazel
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+module(
+    name = "rules_hugo",
+    version = "0.1.0",
+    compatibility_level = 1,
+)
+
+# rules_hugo has no module dependencies: its rules use only @bazel_tools.
+#
+# The `hugo` extension provides the hugo binary repository. The default
+# `@hugo//:hugo` the rules depend on must be visible from THIS module's
+# repo mapping, so the extension is used here; a root module that declares
+# its own `hugo.download(...)` tag wins over the default below, because
+# extension tags are iterated root-first.
+hugo = use_extension("//hugo:extensions.bzl", "hugo")
+hugo.download(
+    version = "0.91.2",
+    extended = True,
+    sha256 = "e9e2b35ebef6ed41581eb18909b8ee02ee9285d209f7d9ecc5caf5207b7dc8e5",
+)
+use_repo(hugo, "hugo")

--- a/modules/rules_hugo/0.1.0/overlay/MODULE.bazel
+++ b/modules/rules_hugo/0.1.0/overlay/MODULE.bazel
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+module(
+    name = "rules_hugo",
+    version = "0.1.0",
+    compatibility_level = 1,
+)
+
+# rules_hugo has no module dependencies: its rules use only @bazel_tools.
+#
+# The `hugo` extension provides the hugo binary repository. The default
+# `@hugo//:hugo` the rules depend on must be visible from THIS module's
+# repo mapping, so the extension is used here; a root module that declares
+# its own `hugo.download(...)` tag wins over the default below, because
+# extension tags are iterated root-first.
+hugo = use_extension("//hugo:extensions.bzl", "hugo")
+hugo.download(
+    version = "0.91.2",
+    extended = True,
+    sha256 = "e9e2b35ebef6ed41581eb18909b8ee02ee9285d209f7d9ecc5caf5207b7dc8e5",
+)
+use_repo(hugo, "hugo")

--- a/modules/rules_hugo/0.1.0/overlay/hugo/extensions.bzl
+++ b/modules/rules_hugo/0.1.0/overlay/hugo/extensions.bzl
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Module extension that sets up the hugo binary repository.
+
+The `hugo_repository` repository rule predates bzlmod; this extension makes it
+usable from MODULE.bazel:
+
+    hugo = use_extension("@rules_hugo//hugo:extensions.bzl", "hugo")
+    hugo.download(version = "0.91.2", extended = True, sha256 = "...")
+    use_repo(hugo, "hugo")
+
+The generated repository is named `hugo` by default, which is what the
+`hugo_site` rule's `hugo` attribute points at.
+"""
+
+load("//hugo:internal/hugo_repository.bzl", "hugo_repository")
+
+_download = tag_class(
+    doc = "Declares the hugo release binary to download.",
+    attrs = {
+        "name": attr.string(
+            default = "hugo",
+            doc = "Name of the generated repository.",
+        ),
+        "version": attr.string(
+            mandatory = True,
+            doc = "The hugo version to download, e.g. \"0.91.2\".",
+        ),
+        "sha256": attr.string(
+            doc = "sha256 of the release archive for this platform.",
+        ),
+        "extended": attr.bool(
+            default = False,
+            doc = "Download the extended hugo build.",
+        ),
+        "os_arch": attr.string(
+            doc = "Override the os/arch archive suffix; autodetected when empty.",
+        ),
+    },
+)
+
+def _hugo_impl(mctx):
+    seen = {}
+    for mod in mctx.modules:
+        for tag in mod.tags.download:
+            if tag.name in seen:
+                # First declaration wins; root modules are iterated first.
+                continue
+            seen[tag.name] = True
+            hugo_repository(
+                name = tag.name,
+                version = tag.version,
+                sha256 = tag.sha256,
+                extended = tag.extended,
+                os_arch = tag.os_arch,
+            )
+
+hugo = module_extension(
+    implementation = _hugo_impl,
+    tag_classes = {"download": _download},
+)

--- a/modules/rules_hugo/0.1.0/patches/bazel9_bzlmod.patch
+++ b/modules/rules_hugo/0.1.0/patches/bazel9_bzlmod.patch
@@ -1,0 +1,138 @@
+diff --git a/hugo/internal/hugo_site.bzl b/hugo/internal/hugo_site.bzl
+index 05d537e..b066a31 100644
+--- a/hugo/internal/hugo_site.bzl
++++ b/hugo/internal/hugo_site.bzl
+@@ -1,3 +1,5 @@
++load("//hugo:internal/hugo_theme.bzl", "HugoThemeInfo")
++
+ def relative_path(src, dirname):
+     """Given a src File and a directory it's under, return the relative path.
+ 
+@@ -27,11 +29,11 @@ def copy_to_dir(ctx, srcs, dirname):
+     for i in srcs:
+         if i.is_source:
+             o = ctx.actions.declare_file(relative_path(i, dirname))
+-            ctx.actions.run(
++            ctx.actions.run_shell(
+                 inputs = [i],
+-                executable = "cp",
+-                arguments = ["-r", "-L", i.path, o.path],
+                 outputs = [o],
++                command = 'cp -r -L "$1" "$2"',
++                arguments = [i.path, o.path],
+             )
+             outs.append(o)
+         else:
+@@ -90,9 +92,23 @@ def _hugo_site_impl(ctx):
+     }.items():
+         hugo_inputs += copy_to_dir(ctx, srcs, name)
+ 
++    # Copy whole source directories into static/. Directory inputs sidestep
++    # per-file labels, which cannot be formed for files whose names contain
++    # a colon (Bazel's label separator) -- such files do occur in generated
++    # site content (e.g. chunked HTML book exports).
++    for d in ctx.files.static_dirs:
++        o = ctx.actions.declare_directory("static/" + d.basename)
++        ctx.actions.run_shell(
++            inputs = [d],
++            outputs = [o],
++            command = 'cp -r -L "$1/." "$2"',
++            arguments = [d.path, o.path],
++        )
++        hugo_inputs.append(o)
++
+     # Copy the theme
+     if ctx.attr.theme:
+-        theme = ctx.attr.theme.hugo_theme
++        theme = ctx.attr.theme[HugoThemeInfo]
+         hugo_args += ["--theme", theme.name]
+         for i in theme.files.to_list():
+             path_list = i.short_path.split("/")
+@@ -176,6 +192,12 @@ hugo_site = rule(
+         "static": attr.label_list(
+             allow_files = True,
+         ),
++        # Source DIRECTORIES copied wholesale under static/, keeping their
++        # basename. Use for trees holding files whose names cannot appear in
++        # a label (e.g. containing ':').
++        "static_dirs": attr.label_list(
++            allow_files = True,
++        ),
+         # Files to be included in the images/ subdir
+         "images": attr.label_list(
+             allow_files = True,
+@@ -201,12 +223,12 @@ hugo_site = rule(
+             default = "@hugo//:hugo",
+             allow_files = True,
+             executable = True,
+-            cfg = "host",
++            cfg = "exec",
+         ),
+         # Optionally set the base_url as a hugo argument
+         "base_url": attr.string(),
+         "theme": attr.label(
+-            providers = ["hugo_theme"],
++            providers = [HugoThemeInfo],
+         ),
+         # Emit quietly
+         "quiet": attr.bool(
+@@ -285,7 +307,7 @@ hugo_serve = rule(
+             default = "@hugo//:hugo",
+             allow_files = True,
+             executable = True,
+-            cfg = "host",
++            cfg = "exec",
+         ),
+         "dep": attr.label_list(
+             mandatory=True,
+diff --git a/hugo/internal/hugo_theme.bzl b/hugo/internal/hugo_theme.bzl
+index 600ba16..75c14e3 100644
+--- a/hugo/internal/hugo_theme.bzl
++++ b/hugo/internal/hugo_theme.bzl
+@@ -1,11 +1,20 @@
++"""Hugo theme rule."""
++
++HugoThemeInfo = provider(
++    doc = "A Hugo theme: its name, package path, and files.",
++    fields = {
++        "name": "string: the theme name (the directory name under themes/).",
++        "path": "string: the package the theme files live under.",
++        "files": "depset[File]: every file of the theme.",
++    },
++)
++
+ def _hugo_theme_impl(ctx):
+-    return struct(
+-        hugo_theme = struct(
+-            name = ctx.attr.theme_name or ctx.label.name,
+-            path = ctx.label.package,
+-            files = depset(ctx.files.srcs),
+-        ),
+-    )
++    return [HugoThemeInfo(
++        name = ctx.attr.theme_name or ctx.label.name,
++        path = ctx.label.package,
++        files = depset(ctx.files.srcs),
++    )]
+ 
+ hugo_theme = rule(
+     attrs = {
+diff --git a/hugo/rules.bzl b/hugo/rules.bzl
+index aae2caa..feabe54 100644
+--- a/hugo/rules.bzl
++++ b/hugo/rules.bzl
+@@ -1,6 +1,6 @@
+ load("//hugo:internal/hugo_repository.bzl", _hugo_repository = "hugo_repository")
+ load("//hugo:internal/hugo_site.bzl", _hugo_site = "hugo_site", _hugo_serve = "hugo_serve")
+-load("//hugo:internal/hugo_theme.bzl", _hugo_theme = "hugo_theme")
++load("//hugo:internal/hugo_theme.bzl", _hugo_theme = "hugo_theme", _HugoThemeInfo = "HugoThemeInfo")
+ load("//hugo:internal/github_hugo_theme.bzl", _github_hugo_theme = "github_hugo_theme")
+ 
+ hugo_repository = _hugo_repository
+@@ -11,4 +11,6 @@ hugo_site = _hugo_site
+ 
+ hugo_theme = _hugo_theme
+ 
++HugoThemeInfo = _HugoThemeInfo
++
+ github_hugo_theme = _github_hugo_theme

--- a/modules/rules_hugo/0.1.0/presubmit.yml
+++ b/modules/rules_hugo/0.1.0/presubmit.yml
@@ -1,0 +1,12 @@
+# The rules only need to load and analyze; building a real site is
+# exercised by the consuming repositories' CI.
+matrix:
+  platform: [ubuntu2204]
+  bazel: [9.x]
+tasks:
+  verify_targets:
+    name: Verify build targets
+    platform: ${{ platform }}
+    bazel: ${{ bazel }}
+    build_targets:
+    - '@rules_hugo//hugo/...'

--- a/modules/rules_hugo/0.1.0/source.json
+++ b/modules/rules_hugo/0.1.0/source.json
@@ -1,0 +1,13 @@
+{
+    "url": "https://github.com/stackb/rules_hugo/archive/294a8ec626a394011d35397108c930be631ab9fa.tar.gz",
+    "integrity": "sha256-z50qDF5BjyrXTvTf80uvqULmJfX2xgikHZVVwGbIrdk=",
+    "strip_prefix": "rules_hugo-294a8ec626a394011d35397108c930be631ab9fa",
+    "overlay": {
+        "MODULE.bazel": "sha256-1IwlAQs2PaJUKmyQkZ2mZm3If13o3/ml5wiwUDBqcmk=",
+        "hugo/extensions.bzl": "sha256-5C0Tebl3A7cNGgQLV90o50K4HWViScoYCQ0uj4nTb1k="
+    },
+    "patches": {
+        "bazel9_bzlmod.patch": "sha256-5TDRKwx6CQY6msbSF8F3fcK2iufXxAGMTMH5A+WaTmU="
+    },
+    "patch_strip": 1
+}

--- a/modules/rules_hugo/metadata.json
+++ b/modules/rules_hugo/metadata.json
@@ -1,0 +1,18 @@
+{
+    "homepage": "https://github.com/stackb/rules_hugo",
+    "maintainers": [
+        {
+            "name": "Filip Filmar",
+            "email": "246576+filmil@users.noreply.github.com",
+            "github": "filmil",
+            "github_user_id": 246576
+        }
+    ],
+    "repository": [
+        "github:stackb/rules_hugo"
+    ],
+    "versions": [
+        "0.1.0"
+    ],
+    "yanked_versions": {}
+}


### PR DESCRIPTION
Overlay entry for `stackb/rules_hugo` at `294a8ec62` — upstream ships no tags
and no `MODULE.bazel`, so the overlay adds `MODULE.bazel` plus a `hugo` module
extension (bzlmod wrapper for its `hugo_repository` rule), and one patch
modernizes the rules for Bazel 9:

* `hugo_theme` → real `HugoThemeInfo` provider (legacy struct providers are
  gone in Bazel 9); `hugo_site` consumes it.
* `cfg = "host"` → `cfg = "exec"`.
* bare-string `cp` executable → `run_shell`.
* new `hugo_site.static_dirs` attribute: whole source directories copied under
  `static/`, needed because generated book exports contain files with `:` in
  their names, which cannot be spelled as Bazel labels.

**Verified**: `filmil/hdlfactory.com.template` built against this entry served
as a `file://` registry resolves, fetches, patches and renders a site
**byte-for-byte identical** to a plain `hugo` build (1283 pages, `diff -r`
clean).

Needed by filmil/hdlfactory.com.template#55 (Bazel + rules_hugo migration);
the site PR depends on this entry being live.

This pull request has been created by an automated coding assistant, with
human supervision.

Prompt used to generate the pull request:

    now, fix: https://github.com/filmil/hdlfactory.com.template/issues/55