### PR TITLE
fix(ci): never deploy an empty registry index

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,8 @@ on:
   push:
     branches: [ main ]
     tags: [ "*" ]
+  # Manual re-runs, e.g. to redeploy after a bad publish.
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -24,11 +26,28 @@ jobs:
         run: "bazel build //..."
       - name: "Build module index"
         run: "bazel build //modules:index"
+      # Stage the artifact into a plain directory and REFUSE to deploy an
+      # empty or missing index. On 2026-08-26 a deploy published an empty
+      # publish_dir and deleted the live page (the site template then
+      # propagated the deletion to hdlfactory.com/bazel-registry). Copying
+      # out of bazel-bin also avoids handing the deploy action a path
+      # behind Bazel's convenience symlink.
+      - name: "Stage the index for deploy"
+        run: |
+          set -o errexit -o nounset -o pipefail
+          mkdir -p deploy-staging
+          cp -L bazel-bin/modules/index.html deploy-staging/index.html
+          chmod 644 deploy-staging/index.html
+          test -s deploy-staging/index.html
+          grep -q "module-card" deploy-staging/index.html || {
+            echo "::error::generated index.html has no module cards; refusing to deploy" >&2
+            exit 1
+          }
       - name: "Deploy everything"
         uses: peaceiris/actions-gh-pages@v4
         with:
           external_repository: filmil/hdlfactory.com.template
-          publish_dir: ./bazel-bin/modules
+          publish_dir: ./deploy-staging
           destination_dir: static/bazel-registry
           publish_branch: main
           deploy_key: "${{ secrets.DEPLOY_KEY }}"


### PR DESCRIPTION
## What broke

The 04:57 Release run (after #757 merged) published an **empty publish_dir**:
its deploy commit
[hdlfactory.com.template@9699a42](https://github.com/filmil/hdlfactory.com.template/commit/9699a42)
deleted `static/bazel-registry/index.html` (8184 deletions, zero additions),
and the site build then propagated that to
https://hdlfactory.com/bazel-registry/ → 404.

The build itself is fine: the same two commands at the same commit
(`bazel build //...` then `bazel build //modules:index`, fresh output base)
produce a correct 504 KB index locally, rules_hugo entry included. The empty
directory was environmental — most plausibly the deploy action's handling of
`publish_dir: ./bazel-bin/modules` behind Bazel's convenience symlink.

## The fix

* Stage the artifact: copy (dereferenced, mode 644) into a plain
  `deploy-staging/` dir; publish that — the deploy action never touches the
  Bazel symlink tree.
* Guard it: the step fails loudly if `index.html` is missing, empty, or
  contains no module cards. A bad build now stops the deploy instead of
  erasing the live page.
* Add `workflow_dispatch` so Release can be re-run by hand.

## Healing the site

**Merging this PR is the fix**: the push to `main` triggers Release, which
redeploys the index into the template's `static/bazel-registry/`, and the
template's own CI then redeploys the site. No manual artifact surgery needed.

This pull request has been created by an automated coding assistant, with
human supervision.

Prompt used to generate the pull request:

    https://hdlfactory.com/bazel-registry/ seems broken now

    you can check https://github.com/filmil/hdlfactory.com for what *is* there