### PR TITLE
fix(ci): deploy the registry index with plain git

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,13 +43,33 @@ jobs:
             echo "::error::generated index.html has no module cards; refusing to deploy" >&2
             exit 1
           }
+      # Plain git instead of peaceiris/actions-gh-pages: on 2026-08-26 the
+      # action's copy step started silently transferring zero files from the
+      # publish dir (coinciding with the runners forcing its Node 20 runtime
+      # to Node 24), which deployed deletions of the live page. git and cp
+      # have no such failure mode, and the step refuses to push a deletion.
       - name: "Deploy everything"
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          external_repository: filmil/hdlfactory.com.template
-          publish_dir: ./deploy-staging
-          destination_dir: static/bazel-registry
-          publish_branch: main
-          deploy_key: "${{ secrets.DEPLOY_KEY }}"
-      - name: "Kill ssh-agent, see: https://github.com/peaceiris/actions-gh-pages/issues/909"
-        run: "killall ssh-agent"
+        env:
+          DEPLOY_KEY: ${{ secrets.DEPLOY_KEY }}
+        run: |
+          set -o errexit -o nounset -o pipefail
+          mkdir -p "$HOME/.ssh"
+          printf '%s\n' "$DEPLOY_KEY" > "$HOME/.ssh/registry_deploy"
+          chmod 600 "$HOME/.ssh/registry_deploy"
+          export GIT_SSH_COMMAND="ssh -i $HOME/.ssh/registry_deploy -o StrictHostKeyChecking=accept-new"
+
+          git clone --depth=1 --single-branch --branch main \
+            git@github.com:filmil/hdlfactory.com.template.git site-template
+          mkdir -p site-template/static/bazel-registry
+          cp deploy-staging/index.html site-template/static/bazel-registry/index.html
+
+          cd site-template
+          test -s static/bazel-registry/index.html
+          git add static/bazel-registry/index.html
+          if git diff --cached --quiet; then
+            echo "index.html unchanged; nothing to deploy."
+            exit 0
+          fi
+          git -c user.name=filmil -c user.email=filmil@users.noreply.github.com \
+            commit -m "deploy: filmil/bazel-registry@${GITHUB_SHA}"
+          git push origin main


### PR DESCRIPTION
Follow-up to #758, which turned out to be necessary but not sufficient.

## What the guarded run proved

The 05:11 Release run passed the new guard — `deploy-staging/index.html`
existed, non-empty, module cards present — and **peaceiris/actions-gh-pages
still copied zero files** out of that plain directory. Its deploy commit
([template@33c71b7c](https://github.com/filmil/hdlfactory.com.template/commit/33c71b7c))
created only `.nojekyll`. So the symlink theory is dead: the action's copy
step itself silently transfers nothing.

Timeline: copy worked at 04:32, silently broke by 04:57, no workflow change in
between — coinciding with the runners forcibly migrating the action's Node 20
runtime to Node 24 (the deprecation warnings appear in exactly these runs).

## The fix

The deploy step is now ~15 lines of git: clone the site template, `cp` the
staged index into `static/bazel-registry/`, commit, push over the same
`DEPLOY_KEY`. Properties the action could not give us:

* `cp` has no silent-zero-files failure mode;
* the step only ever adds or updates the one file — **it cannot deploy a
  deletion**;
* an unchanged index exits cleanly with no empty commit.

## Healing

Merging triggers Release on push → index restored in the template →
template CI redeploys the site → https://hdlfactory.com/bazel-registry/ is
back. I am watching both runs.

This pull request has been created by an automated coding assistant, with
human supervision.

Prompt used to generate the pull request:

    watch both now.