### PR TITLE
fix(ci): git add -f the deployed index

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,10 @@ jobs:
 
           cd site-template
           test -s static/bazel-registry/index.html
-          git add static/bazel-registry/index.html
+          # -f: the deploy is unconditional by intent; it must not depend on
+          # the consuming repository's .gitignore (an unanchored bazel-* there
+          # is exactly what caused the 2026-08-26 outage).
+          git add -f static/bazel-registry/index.html
           if git diff --cached --quiet; then
             echo "index.html unchanged; nothing to deploy."
             exit 0


### PR DESCRIPTION
The plain-git deploy from #759 failed **loudly** where peaceiris had failed
silently — and the error names the true root cause of the whole outage:

```
The following paths are ignored by one of your .gitignore files:
static/bazel-registry
```

The site template's unanchored `bazel-*` gitignore line (added with its Bazel
migration) matches `static/bazel-registry` at any depth. peaceiris's
`git add --all` silently skipped the path (hence commits that only deleted);
plain `git add` refuses with an error — which is how we finally saw it. The
Node-24 suspicion in #759 was wrong.

`git add -f` makes the deploy independent of consumer gitignore choices. The
template's gitignore is being anchored separately in
[hdlfactory.com.template#60](https://github.com/filmil/hdlfactory.com.template/pull/60).

**Merging this PR triggers Release on push and heals the page.** Either merge
order relative to #60 works.

This pull request has been created by an automated coding assistant, with
human supervision.

Prompt used to generate the pull request:

    deploy failed:
    https://github.com/filmil/bazel-registry/actions/runs/32933448433/job/98070034830