### PR TITLE
chore(texlive_bundle): add 1.1.0

### DIFF
--- a/modules/texlive_bundle/1.1.0/MODULE.bazel
+++ b/modules/texlive_bundle/1.1.0/MODULE.bazel
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+module(
+    name = "texlive_bundle",
+    version = "1.1.0",
+    compatibility_level = 1,
+)
+
+# For //latex:toolchain.bzl (the `latex_toolchain` rule) and the toolchain
+# type the bound toolchain implements.
+bazel_dep(name = "rules_latex_host", version = "0.1.0")
+
+# For the exec constraints on the toolchain (@platforms//os:linux, ...).
+bazel_dep(name = "platforms", version = "0.0.11")

--- a/modules/texlive_bundle/1.1.0/source.json
+++ b/modules/texlive_bundle/1.1.0/source.json
@@ -1,0 +1,5 @@
+{
+    "integrity": "sha256-HkhqwSbwCHl+eVCUysEte3Jp2aHQ0vxttDCu3zyDppk=",
+    "strip_prefix": "texlive_bundle-v1.1.0",
+    "url": "https://github.com/filmil/texlive-bundle/releases/download/v1.1.0/texlive_bundle-v1.1.0.tar.xz"
+}

--- a/modules/texlive_bundle/metadata.json
+++ b/modules/texlive_bundle/metadata.json
@@ -12,7 +12,8 @@
         "github:filmil/texlive-bundle"
     ],
     "versions": [
-        "1.0.0"
+        "1.0.0",
+        "1.1.0"
     ],
     "yanked_versions": {}
 }


### PR DESCRIPTION
## Why this is by hand

`texlive-bundle` **v1.1.0 is released** and its archive is uploaded (196 MB), but the registry entry was never created. The `Tag and Release` run tagged and uploaded fine, then failed in the publish step:

```
Error: ENOENT: no such file or directory, open
'/home/runner/work/_actions/bazel-contrib/publish-to-bcr/b37a76b.../dist/cli/xzdec.wasm.gz'
```

That is a broken `dist/` in the pinned `publish-to-bcr` ref, not anything in the bundle repo. `publish.yml` therefore never opened this PR. This is the entry that step would have produced.

## Integrity

**Not copied from the release metadata.** The archive was downloaded and hashed locally, then compared with the digest GitHub reports for the asset:

```
downloaded sha256 : 1e486ac126f008797e795094cac12d7b7269d9a1d0d2fc6db430aedf3c83a699
github digest     : 1e486ac126f008797e795094cac12d7b7269d9a1d0d2fc6db430aedf3c83a699
```

A wrong integrity here breaks every consumer, so it is worth the download rather than trusting a field.

## Verified against a real consumer

This registry was resolved from disk (`--registry=file://…`) and used to build `hdlfactory.com.template`, which renders its site logo from a TikZ source using `latex` and `dvisvgm` out of the bundle tree:

- `bazel build //static/logo:hf-logo` succeeds against the released v1.1.0 archive.
- The resulting SVG is **byte-identical** to the one produced from a hand-staged distribution.
- `bazel build //:site` publishes it and the nav references it.

That also confirms the point of v1.1.0: `bin/x86_64-linux/dvisvgm` is present in the released tree, which it was not in 1.0.0.

## Worth fixing separately

The `publish-to-bcr` pin will fail the same way on the next release. Bumping it to a ref with an intact `dist/` would stop this recurring — happy to open that separately if useful.

This pull request has been created by an automated coding assistant, with
human supervision.

Prompt used to generate this pull request:

    is the icon deployed - I am not seeing it on hdlfactory the site