### PR TITLE
fix(generate): invert the nav mark when page theme and OS scheme disagree

### DIFF
--- a/cmd/generate/main.go
+++ b/cmd/generate/main.go
@@ -442,6 +442,18 @@ const htmlTemplate = `
       })();
     </script>
     <style>
+      /* The nav mark is an <img>, so the SVG inside cannot see the page's
+         palette: its embedded prefers-color-scheme stylesheet picks the ink
+         from the OS scheme, while this page's data-theme can be toggled away
+         from it. Invert the mark exactly when the two disagree -- the same
+         rules the site theme's head_custom carries. */
+      @media (prefers-color-scheme: light) {
+        html[data-theme="dark"] .brand img { filter: invert(0.85); }
+      }
+      @media (prefers-color-scheme: dark) {
+        html[data-theme="light"] .brand img { filter: invert(0.85); }
+      }
+
       /* Registry-page additions on top of the site theme's tokens. */
       .registry-head {
         display: flex;


### PR DESCRIPTION
Fixes the dark-theme logo report filed against hdlfactory.com.template — the
offending page turns out to be this repo's generated `/bazel-registry/` page,
not the site's own pages.

## Diagnosis

The nav mark is an `<img>` of an SVG whose embedded `prefers-color-scheme`
stylesheet picks its ink from the **OS scheme**; the page's `data-theme` can be
toggled away from that. When they disagree (e.g. OS light, page toggled dark)
the mark rendered dark-on-dark and vanished. The **site theme already
compensates** via two rules in its `head_custom` partial — verified working on
the site's pages — but this page duplicates the nav markup and never got them
(`grep -c invert` = 0 on the deployed page).

## Fix

The generator's template now carries the identical two rules: invert the mark
exactly when `data-theme` and `prefers-color-scheme` disagree.

Verified headless: the generated page with theme toggled dark on a
light-scheme host shows the mark correctly (before: invisible). `bazel test
//cmd/...` passes. Merging triggers Release, which deploys via the guarded git
path.

This pull request has been created by an automated coding assistant, with
human supervision.

Prompt used to generate the pull request:

    in https://github.com/filmil/hdlfactory.com.template, the logo does not
    invert in "dark" theme. fix